### PR TITLE
Parser rewrite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "Hardware"]
 	path = Hardware
 	url = https://github.com/Ultrawipf/OpenFFBoard-hardware.git
+	branch = master
 [submodule "Configurator"]
 	path = Configurator
 	url = https://github.com/Ultrawipf/OpenFFBoard-configurator
+	branch = master

--- a/Firmware/Inc/CmdParser.h
+++ b/Firmware/Inc/CmdParser.h
@@ -50,7 +50,7 @@ public:
 	bool add(char* Buf, uint32_t *Len);
 	std::vector<ParsedCommand> parse();
 
-	const std::string helpstring = "Parser usage:\n Set <cmd>=<int>/<cmd>?<adr>=<var>\n Get: <cmd>?/<cmd>?<var>\nInfo: <cmd>!\ndelims: ;/CR/NL/SPACE";
+	const std::string helpstring = "Parser usage:\n Set cmd=int/cmd?adr=var\n Get: cmd?/cmd?var\nInfo: cmd!\ndelims: ;/CR/NL/SPACE";
 };
 
 #endif /* CMDPARSER_H_ */

--- a/Firmware/Inc/CmdParser.h
+++ b/Firmware/Inc/CmdParser.h
@@ -50,7 +50,7 @@ public:
 	bool add(char* Buf, uint32_t *Len);
 	std::vector<ParsedCommand> parse();
 
-	const std::string helpstring = "Parser usage:\n Set <cmd>=<int>/<cmd>?<adr>=<var>\n Get: <cmd>?/<cmd>?<var>\nInfo: <cmd>!\ndelims: [;/CR/NL/SPACE]";
+	const std::string helpstring = "Parser usage:\n Set <cmd>=<int>/<cmd>?<adr>=<var>\n Get: <cmd>?/<cmd>?<var>\nInfo: <cmd>!\ndelims: ;/CR/NL/SPACE";
 };
 
 #endif /* CMDPARSER_H_ */

--- a/Firmware/Inc/CommandHandler.h
+++ b/Firmware/Inc/CommandHandler.h
@@ -10,6 +10,8 @@
 #include <CmdParser.h>
 #include "ClassChooser.h"
 
+enum class ParseStatus : uint8_t {NOT_FOUND,OK,ERR,OK_CONTINUE};
+
 /*
  * Implements an interface for parsed command handlers
  * Adds itself to a global vector of handlers that can be called from the main class when a command gets parsed
@@ -21,7 +23,7 @@ public:
 	virtual ~CommandHandler();
 	virtual bool hasCommands();
 	virtual void setCommandsEnabled(bool enable);
-	virtual bool command(ParsedCommand* cmd,std::string* reply);
+	virtual ParseStatus command(ParsedCommand* cmd,std::string* reply);
 	virtual const ClassIdentifier getInfo() = 0; // Command handlers always have class infos. Works well with ChoosableClass
 protected:
 	bool commandsEnabled = true;

--- a/Firmware/Inc/LocalButtons.h
+++ b/Firmware/Inc/LocalButtons.h
@@ -22,7 +22,7 @@ public:
 
 	const uint16_t maxButtons = 8;
 
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 	void saveFlash(); 		// Write to flash here
 	void restoreFlash();	// Load from flash

--- a/Firmware/Inc/MotorPWM.h
+++ b/Firmware/Inc/MotorPWM.h
@@ -44,7 +44,7 @@ public:
 	void saveFlash(); 		// Write to flash here
 	void restoreFlash();	// Load from flash
 
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 	void setPWM(uint32_t value);
 

--- a/Firmware/Inc/SPIButtons.h
+++ b/Firmware/Inc/SPIButtons.h
@@ -36,7 +36,7 @@ public:
 
 	void readButtons(uint32_t* buf);
 
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 	void saveFlash();
 	void restoreFlash();

--- a/Firmware/Inc/ShifterAnalog.h
+++ b/Firmware/Inc/ShifterAnalog.h
@@ -45,7 +45,7 @@ public:
 
 	void printModes(std::string* reply);
 
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 private:
 	ShifterMode mode;

--- a/Firmware/Inc/TMC4671.h
+++ b/Firmware/Inc/TMC4671.h
@@ -289,7 +289,7 @@ public:
 
 	bool allowSlowSPI = true; // For engineering sample
 
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 	void HAL_SPI_TXRX_COMPLETE();
 

--- a/Firmware/Inc/constants.h
+++ b/Firmware/Inc/constants.h
@@ -8,7 +8,7 @@
 // Timer 3 is used by the encoder. All other timers are free to use
 #define TIM_MICROS htim5
 
-#define SW_VERSION "1.0.6" // Version string
+#define SW_VERSION "1.1.0" // Version string
 
 #define ADC_CHANNELS 9 	// how many analog input values to be read by dma
 

--- a/Firmware/Inc/global_callbacks.h
+++ b/Firmware/Inc/global_callbacks.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 void CDC_Callback(uint8_t* Buf, uint32_t *Len);
+void CDC_Finished();
 void USBD_OutEvent_HID(uint8_t* report);
 void USB_SOF();
 void USBD_GetEvent_HID(uint8_t id,uint16_t len,uint8_t** return_buf);

--- a/Firmware/Src/CmdParser.cpp
+++ b/Firmware/Src/CmdParser.cpp
@@ -29,11 +29,10 @@ bool CmdParser::add(char* Buf, uint32_t *Len){
 		if(*(Buf+i) == '\n' || *(Buf+i) == '\r' || *(Buf+i) == ';'|| *(Buf+i) == ' '){
 			*(Buf+i) = (uint8_t)';';
 			flag = true;
+
 		}
 	}
-
 	this->buffer.append((char*)Buf,*Len);
-
 	return flag;
 }
 
@@ -44,15 +43,16 @@ std::vector<ParsedCommand> CmdParser::parse(){
 	std::vector<ParsedCommand> commands;
 	std::vector<std::string> tokens;
 
-    uint16_t pos = 0;
-    uint16_t lpos = 0;
+    uint32_t pos = 0;
+    uint32_t lpos = 0;
 	while(pos < buffer.length()-1){
 		pos = buffer.find(';',lpos);
-		std::string token = buffer.substr(lpos,pos-lpos);
-		lpos = pos+1;
-		tokens.push_back(token);
+		if(pos != std::string::npos){
+			std::string token = buffer.substr(lpos,pos-lpos);
+			lpos = pos+1;
+			tokens.push_back(token);
+		}
 	}
-
 	for(std::string word : tokens){
 
 		ParsedCommand cmd;
@@ -104,6 +104,7 @@ std::vector<ParsedCommand> CmdParser::parse(){
 
 		commands.push_back(cmd);
 	}
-	buffer.clear();
+
+	buffer.erase(0,lpos); // Clear parsed portion from buffer
 	return commands;
 }

--- a/Firmware/Src/CommandHandler.cpp
+++ b/Firmware/Src/CommandHandler.cpp
@@ -13,6 +13,7 @@ CommandHandler::CommandHandler() {
 	addCommandHandler();
 }
 
+
 CommandHandler::~CommandHandler() {
 	// Remove from global list when deleted
 	removeCommandHandler();
@@ -33,14 +34,14 @@ const ClassIdentifier CommandHandler::getInfo(){
 }
 /*
  * Implement this function
- * MUST return false when no valid command was found or if a help command or similar was parsed
- * When it returns true parsing is normally stopped after this class and not sent to others
+ * MUST return not found when no valid command was found or if a help command or similar was parsed
+ * When it returns OK or FAIL parsing is normally stopped after this class and the command is not sent to others
  */
-bool CommandHandler::command(ParsedCommand* cmd,std::string* reply){
+ParseStatus CommandHandler::command(ParsedCommand* cmd,std::string* reply){
 	if(!this->commandsEnabled){
-		return false;
+		return ParseStatus::NOT_FOUND;
 	}
-	return false;
+	return ParseStatus::NOT_FOUND;
 }
 
 

--- a/Firmware/Src/LocalButtons.cpp
+++ b/Firmware/Src/LocalButtons.cpp
@@ -57,8 +57,8 @@ void LocalButtons::restoreFlash(){
 	}
 }
 
-bool LocalButtons::command(ParsedCommand* cmd,std::string* reply){
-	bool result = true;
+ParseStatus LocalButtons::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus result = ParseStatus::OK;
 	// mask is a bitfield of 8 bits enabling or disabling specific pins
 	if(cmd->cmd == "local_btnmask"){
 		if(cmd->type == CMDtype::set){
@@ -67,7 +67,7 @@ bool LocalButtons::command(ParsedCommand* cmd,std::string* reply){
 			*reply += std::to_string(this->mask);
 		}
 	}else{
-		result = false; // No valid command
+		result = ParseStatus::NOT_FOUND; // No valid command
 	}
 
 	return result;

--- a/Firmware/Src/MotorPWM.cpp
+++ b/Firmware/Src/MotorPWM.cpp
@@ -196,8 +196,8 @@ ModePWM_DRV MotorPWM::getMode(){
 
 
 
-bool MotorPWM::command(ParsedCommand* cmd,std::string* reply){
-	bool result = true;
+ParseStatus MotorPWM::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus result = ParseStatus::OK;
 
 	if(cmd->cmd == "pwm_mode"){
 		if(cmd->type == CMDtype::set){
@@ -226,7 +226,7 @@ bool MotorPWM::command(ParsedCommand* cmd,std::string* reply){
 			}
 		}
 	}else{
-		result = false; // No valid command
+		result = ParseStatus::NOT_FOUND; // No valid command
 	}
 
 	return result;

--- a/Firmware/Src/SPIButtons.cpp
+++ b/Firmware/Src/SPIButtons.cpp
@@ -125,8 +125,8 @@ void SPI_Buttons::printModes(std::string* reply){
 	}
 }
 
-bool SPI_Buttons::command(ParsedCommand* cmd,std::string* reply){
-	bool result = true;
+ParseStatus SPI_Buttons::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus result = ParseStatus::OK;
 	if(cmd->cmd == "spi_btnnum"){
 		if(cmd->type == CMDtype::set){
 			ButtonSourceConfig* c = this->getConfig();
@@ -172,7 +172,7 @@ bool SPI_Buttons::command(ParsedCommand* cmd,std::string* reply){
 			printModes(reply);
 		}
 	}else{
-		result = false;
+		result = ParseStatus::NOT_FOUND;
 	}
 	return result;
 }

--- a/Firmware/Src/SPIButtons.cpp
+++ b/Firmware/Src/SPIButtons.cpp
@@ -163,7 +163,7 @@ ParseStatus SPI_Buttons::command(ParsedCommand* cmd,std::string* reply){
 		}else{
 			*reply+="Err. cut bytes right: 1 else 0";
 		}
-	}if(cmd->cmd == "spibtn_mode"){
+	}else if(cmd->cmd == "spibtn_mode"){
 		if(cmd->type == CMDtype::set){
 			setMode((SPI_BtnMode)cmd->val);
 		}else if(cmd->type == CMDtype::get){

--- a/Firmware/Src/ShifterAnalog.cpp
+++ b/Firmware/Src/ShifterAnalog.cpp
@@ -103,8 +103,8 @@ void ShifterAnalog::printModes(std::string* reply){
 	}
 }
 
-bool ShifterAnalog::command(ParsedCommand* cmd,std::string* reply){
-	bool result = true;
+ParseStatus ShifterAnalog::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus result = ParseStatus::OK;
 	// use "shifter_mode!" to print a list of possible modes and choose one
 	if(cmd->cmd == "shifter_mode"){
 		if(cmd->type == CMDtype::set){
@@ -115,7 +115,7 @@ bool ShifterAnalog::command(ParsedCommand* cmd,std::string* reply){
 			printModes(reply);
 		}
 	}else{
-		result = false;
+		result = ParseStatus::NOT_FOUND;
 	}
 	return result;
 }

--- a/Firmware/Src/TMC4671.cpp
+++ b/Firmware/Src/TMC4671.cpp
@@ -1178,8 +1178,8 @@ void TMC4671::restoreEncHallMisc(uint16_t val){
 }
 
 
-bool TMC4671::command(ParsedCommand* cmd,std::string* reply){
-	bool flag = true;
+ParseStatus TMC4671::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus flag = ParseStatus::OK;
 	if(cmd->cmd == "mtype"){
 		if(cmd->type == CMDtype::get){
 			*reply+=std::to_string((uint8_t)this->conf.motconf.motor_type);
@@ -1204,7 +1204,7 @@ bool TMC4671::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type ==CMDtype:: set){
 			this->bangInitEnc(cmd->val);
 		}else{
-			return false;
+			return ParseStatus::OK_CONTINUE;
 		}
 		if(this->checkEncoder()){
 			*reply+=">Aligned";
@@ -1295,13 +1295,13 @@ bool TMC4671::command(ParsedCommand* cmd,std::string* reply){
 		}
 
 	}else if(cmd->cmd == "help"){
-		flag = false; // Set flag false to continue parsing
+		flag = ParseStatus::OK_CONTINUE; // Set flag false to continue parsing
 		*reply += "TMC4671 commands:\n"
 				"mtype,encsrc,encalign,poles,phiesrc,reg,fluxoffset\n"
 				"torqueP,torqueI,fluxP,fluxI\n"
 				"acttorque,seqpi\n";
 	}else{
-		flag = false;
+		flag = ParseStatus::NOT_FOUND;
 	}
 	return flag;
 }

--- a/Firmware/Src/TMC4671.cpp
+++ b/Firmware/Src/TMC4671.cpp
@@ -1225,7 +1225,7 @@ ParseStatus TMC4671::command(ParsedCommand* cmd,std::string* reply){
 			this->setCpr(cmd->val);
 		}
 
-	}else if(cmd->cmd == "acttorque"){
+	}else if(cmd->cmd == "acttrq"){
 		if(cmd->type == CMDtype::get){
 			*reply+=std::to_string(getActualCurrent());
 		}
@@ -1299,7 +1299,7 @@ ParseStatus TMC4671::command(ParsedCommand* cmd,std::string* reply){
 		*reply += "TMC4671 commands:\n"
 				"mtype,encsrc,encalign,poles,phiesrc,reg,fluxoffset\n"
 				"torqueP,torqueI,fluxP,fluxI\n"
-				"acttorque,seqpi\n";
+				"acttrq,seqpi\n";
 	}else{
 		flag = ParseStatus::NOT_FOUND;
 	}

--- a/Firmware/Src/global_callbacks.cpp
+++ b/Firmware/Src/global_callbacks.cpp
@@ -84,6 +84,10 @@ void CDC_Callback(uint8_t* Buf, uint32_t *Len){
 	if(mainclass!=nullptr)
 		mainclass->cdcRcv((char*)Buf,Len);
 }
+void CDC_Finished(){
+	if(mainclass!=nullptr)
+		mainclass->cdcFinished();
+}
 
 // USB Out Endpoint callback
 UsbHidHandler* globalHidHandler = nullptr;

--- a/Firmware/USB/Inc/usbd_cdc_if.h
+++ b/Firmware/USB/Inc/usbd_cdc_if.h
@@ -135,7 +135,7 @@ extern uint8_t cdc_dtr;
 uint8_t CDC_Transmit_FS(const char* Buf, uint16_t Len);
 
 /* USER CODE BEGIN EXPORTED_FUNCTIONS */
-
+void CDC_Finished();
 /* USER CODE END EXPORTED_FUNCTIONS */
 
 /**

--- a/Firmware/USB/Src/usbd_cdc.c
+++ b/Firmware/USB/Src/usbd_cdc.c
@@ -502,6 +502,7 @@ static uint8_t  USBD_CDC_DataIn (USBD_HandleTypeDef *pdev, uint8_t epnum)
   {
     
     hcdc->TxState = 0;
+    CDC_Finished();
 
     return USBD_OK;
   }

--- a/Firmware/USB/Src/usbd_cdc_if.c
+++ b/Firmware/USB/Src/usbd_cdc_if.c
@@ -333,7 +333,7 @@ uint8_t CDC_Transmit_FS(const char* Buf, uint16_t Len)
 {
 
   /* USER CODE BEGIN 7 */
-  if(hUsbDeviceFS.dev_state != USBD_STATE_CONFIGURED)
+  if(hUsbDeviceFS.dev_state != USBD_STATE_CONFIGURED || hcdc->TxState != 0)
 	  return USBD_FAIL;
   uint8_t result = USBD_OK;
   uint32_t size = sizeof(uint8_t) * Len;
@@ -345,7 +345,6 @@ uint8_t CDC_Transmit_FS(const char* Buf, uint16_t Len)
   size = size < APP_TX_DATA_SIZE ? size : APP_TX_DATA_SIZE;
 
   memcpy(UserTxBufferFS, Buf, size);
-
 
   USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, size);
   result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);

--- a/Firmware/USB/Src/usbd_cdc_if.c
+++ b/Firmware/USB/Src/usbd_cdc_if.c
@@ -337,10 +337,6 @@ uint8_t CDC_Transmit_FS(const char* Buf, uint16_t Len)
 	  return USBD_FAIL;
   uint8_t result = USBD_OK;
   uint32_t size = sizeof(uint8_t) * Len;
-//  uint32_t additional_length = 0;
-
-//  if(hcdc->TxState != 0)
-//	  additional_length = hcdc->TxLength;
 
   size = size < APP_TX_DATA_SIZE ? size : APP_TX_DATA_SIZE;
 

--- a/Firmware/USB/Src/usbd_desc.c
+++ b/Firmware/USB/Src/usbd_desc.c
@@ -138,9 +138,9 @@ __ALIGN_BEGIN uint8_t USBD_FS_DeviceDesc_Composite[USB_LEN_DEV_DESC] __ALIGN_END
     USB_DESC_TYPE_DEVICE,       /*bDescriptorType*/
     0x00,                       /* bcdUSB */
     0x02,
-    0x00,                        /*bDeviceClass*/
-    0x00,                       /*bDeviceSubClass*/
-    0x00,                       /*bDeviceProtocol*/
+    0xEF,                        /*bDeviceClass*/
+    0x02,                       /*bDeviceSubClass*/
+    0x01,                       /*bDeviceProtocol*/
     USB_MAX_EP0_SIZE,          /*bMaxPacketSize*/
     LOBYTE(USBD_VID),           /*idVendor*/
     HIBYTE(USBD_VID),           /*idVendor*/

--- a/Firmware/UserExtensions/Inc/ExampleMain.h
+++ b/Firmware/UserExtensions/Inc/ExampleMain.h
@@ -19,7 +19,7 @@ public:
 
 	static ClassIdentifier info;
 	const ClassIdentifier getInfo();
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 
 private:

--- a/Firmware/UserExtensions/Inc/FFBWheel.h
+++ b/Firmware/UserExtensions/Inc/FFBWheel.h
@@ -55,7 +55,7 @@ public:
 
 	void setupTMC4671();
 	void setupTMC4671_enc(PhiE enctype);
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 	void setDrvType(uint8_t drvtype);
 	void setEncType(uint8_t enctype);

--- a/Firmware/UserExtensions/Inc/FFBoardMain.h
+++ b/Firmware/UserExtensions/Inc/FFBoardMain.h
@@ -31,11 +31,14 @@ public:
 	virtual void update();
 	virtual void cdcRcv(char* Buf, uint32_t *Len);
 	virtual void SOF();
+	virtual void cdcFinished();
 	virtual void usbSuspend(); // Called on usb disconnect and suspend
 	virtual void usbResume(); // Called on usb resume
 
 
 private:
+	bool usb_busy_retry = false;
+	std::string cmd_reply;
 
 protected:
 	virtual void executeCommands(std::vector<ParsedCommand> commands);

--- a/Firmware/UserExtensions/Inc/FFBoardMain.h
+++ b/Firmware/UserExtensions/Inc/FFBoardMain.h
@@ -31,7 +31,7 @@ public:
 	virtual void update();
 	virtual void cdcRcv(char* Buf, uint32_t *Len);
 	virtual void SOF();
-	virtual void cdcFinished();
+	virtual void cdcFinished(); // Cdc send transfer complete
 	virtual void usbSuspend(); // Called on usb disconnect and suspend
 	virtual void usbResume(); // Called on usb resume
 

--- a/Firmware/UserExtensions/Inc/FFBoardMain.h
+++ b/Firmware/UserExtensions/Inc/FFBoardMain.h
@@ -39,8 +39,8 @@ private:
 
 protected:
 	virtual void executeCommands(std::vector<ParsedCommand> commands);
-	virtual bool command(ParsedCommand* cmd,std::string* reply); // Append reply strings to reply buffer
-	virtual bool executeSysCommand(ParsedCommand* cmd,std::string* reply);
+	virtual ParseStatus command(ParsedCommand* cmd,std::string* reply); // Append reply strings to reply buffer
+	virtual ParseStatus executeSysCommand(ParsedCommand* cmd,std::string* reply);
 	CmdParser parser = CmdParser();
 };
 

--- a/Firmware/UserExtensions/Inc/MidiMain.h
+++ b/Firmware/UserExtensions/Inc/MidiMain.h
@@ -44,7 +44,7 @@ public:
 
 	static ClassIdentifier info;
 	const ClassIdentifier getInfo();
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 	void usbInit();
 	void update();
 	void  SOF();

--- a/Firmware/UserExtensions/Inc/TMCDebugBridge.h
+++ b/Firmware/UserExtensions/Inc/TMCDebugBridge.h
@@ -30,7 +30,7 @@ public:
 	const ClassIdentifier getInfo();
 
 	void cdcRcv(char* Buf, uint32_t *Len);
-	bool command(ParsedCommand* cmd,std::string* reply);
+	ParseStatus command(ParsedCommand* cmd,std::string* reply);
 
 
 private:

--- a/Firmware/UserExtensions/Src/ExampleMain.cpp
+++ b/Firmware/UserExtensions/Src/ExampleMain.cpp
@@ -29,8 +29,8 @@ ExampleMain::~ExampleMain() {
 	// TODO Auto-generated destructor stub
 }
 
-bool ExampleMain::command(ParsedCommand* cmd,std::string* reply){
-	bool flag = true; // Valid command found
+ParseStatus ExampleMain::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus flag = ParseStatus::OK; // Valid command found
 
 	// ------------ commands ----------------
 	if(cmd->cmd == "command"){ // Example: command=1337\n
@@ -39,10 +39,10 @@ bool ExampleMain::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type == CMDtype::set){
 			examplevar = cmd->val;
 		}else{
-			*reply += "Err";
+			flag = ParseStatus::ERR;
 		}
 	}else{
-		flag = false; // No valid command
+		flag = ParseStatus::NOT_FOUND; // No valid command
 	}
 	return flag;
 }

--- a/Firmware/UserExtensions/Src/FFBWheel_commands.cpp
+++ b/Firmware/UserExtensions/Src/FFBWheel_commands.cpp
@@ -9,8 +9,8 @@
 #include "FFBWheel.h"
 
 
-bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
-	bool flag = true;
+ParseStatus FFBWheel::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus flag = ParseStatus::OK;
 	// ------------ General commands ----------------
 	if(cmd->cmd == "save"){
 		this->saveFlash();
@@ -21,6 +21,7 @@ bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type == CMDtype::set && this->drv_chooser.isValidClassId(cmd->val)){
 			setDrvType((cmd->val));
 		}else{
+
 			*reply += drv_chooser.printAvailableClasses();
 		}
 	}else if(cmd->cmd == "btntypes"){
@@ -29,6 +30,7 @@ bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type == CMDtype::set){
 			setBtnTypes(cmd->val);
 		}else{
+			flag = ParseStatus::ERR;
 			*reply += "bin flag encoded list of button sources. (3 = source 1 & 2 active). See lsbtn for sources";
 		}
 	}else if(cmd->cmd == "lsbtn"){
@@ -107,6 +109,7 @@ bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type == CMDtype::set && this->enc != nullptr){
 			this->enc->setCpr(cmd->val);
 		}else{
+			flag = ParseStatus::ERR;
 			*reply += "Err. Setup enctype first";
 		}
 	}else if(cmd->cmd == "pos"){
@@ -115,6 +118,7 @@ bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
 		}else if(cmd->type == CMDtype::set && this->enc != nullptr){
 			this->enc->setPos(cmd->val);
 		}else{
+			flag = ParseStatus::ERR;
 			*reply += "Err. Setup enctype first";
 		}
 
@@ -125,11 +129,11 @@ bool FFBWheel::command(ParsedCommand* cmd,std::string* reply){
 		*reply+=std::to_string(ffb->getFfbActive() ? 1 : 0);
 
 	}else if(cmd->cmd == "help"){
-		flag = false;
+		flag = ParseStatus::OK_CONTINUE;
 		*reply += "FFBWheel commands:\n"
 				"power,zeroenc,enctype,degrees,esgain,fxratio,idlespring,friction,invertx,cpr,drvtype,btntype,lsbtn,btnnum,btntypes,btnpol,btncut,axismask,ffbactive\n"; // TODO
 	}else{
-		flag = false;
+		flag = ParseStatus::NOT_FOUND;
 	}
 
 	return flag;

--- a/Firmware/UserExtensions/Src/FFBoardMain.cpp
+++ b/Firmware/UserExtensions/Src/FFBoardMain.cpp
@@ -152,16 +152,15 @@ void FFBoardMain::executeCommands(std::vector<ParsedCommand> commands){
 			reply+='\n';
 		}
 		if(status == ParseStatus::NOT_FOUND){ //No class reported success. Show error
-			reply = "Err. Unknown command: " + cmd.cmd + "\n";
+			reply = "Err(0). Unknown command: " + cmd.cmd + "\n";
 		}else if(status == ParseStatus::ERR){ //Error reported in command
-			reply += "Err. Execution error\n";
+			reply += "Err(1). Execution error\n";
 		}
 		this->cmd_reply+=reply;
 	}
 
 	if(this->cmd_reply.length()>0){ // Check if cdc busy
 		if(CDC_Transmit_FS(this->cmd_reply.c_str(), this->cmd_reply.length()) != USBD_OK){
-			pulseErrLed();
 			this->usb_busy_retry = true;
 		}
 	}

--- a/Firmware/UserExtensions/Src/MidiMain.cpp
+++ b/Firmware/UserExtensions/Src/MidiMain.cpp
@@ -12,7 +12,7 @@
 #include "ledEffects.h"
 
 ClassIdentifier MidiMain::info = {
-		 .name = "MIDI :)" ,
+		 .name = "MIDI" ,
 		 .id=64,
 		 .hidden=false //Set false to list
  };

--- a/Firmware/UserExtensions/Src/MidiMain.cpp
+++ b/Firmware/UserExtensions/Src/MidiMain.cpp
@@ -141,8 +141,8 @@ void MidiMain::pitchBend(uint8_t chan, int16_t val){
 	}
 }
 
-bool MidiMain::command(ParsedCommand* cmd,std::string* reply){
-	bool flag = true; // Valid command found
+ParseStatus MidiMain::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus flag = ParseStatus::OK; // Valid command found
 	if(cmd->cmd == "power"){
 		if(cmd->type == CMDtype::get){
 			*reply+=std::to_string(power);

--- a/Firmware/UserExtensions/Src/TMCDebugBridge.cpp
+++ b/Firmware/UserExtensions/Src/TMCDebugBridge.cpp
@@ -36,8 +36,8 @@ void TMCDebugBridge::tmcReadRegRaw(uint8_t reg,uint8_t* buf){
 	HAL_GPIO_WritePin(this->csport,this->cspin,GPIO_PIN_SET);
 }
 
-bool TMCDebugBridge::command(ParsedCommand* cmd,std::string* reply){
-	bool flag = true;
+ParseStatus TMCDebugBridge::command(ParsedCommand* cmd,std::string* reply){
+	ParseStatus flag = ParseStatus::OK;
 	if(cmd->cmd == "torque"){
 		if(cmd->type == CMDtype::get){
 			*reply+=std::to_string(drv->getTorque());
@@ -71,7 +71,7 @@ bool TMCDebugBridge::command(ParsedCommand* cmd,std::string* reply){
 			drv->writeReg(cmd->adr,cmd->val);
 		}
 	}else{
-		flag = false;
+		flag = ParseStatus::NOT_FOUND;
 	}
 	return flag;
 }


### PR DESCRIPTION
In order to safely use automatic asynchronous commands every command must result in a reply with a start marker.

Every reply will start with ">" and ends with a "\n" newline. This allows for example the GUI to send a bunch of commands and receive a bunch of replies and split them at the start marker and pass the replies easily to callback functions. This also means the start character is never allowed to be used in reply strings normally!

Commands that won't normally result in a reply like "power=1000\n" to set a value will still give back a ">OK\n" reply.
If an invalid command is received the board will reply with an error message. 
For this an enum is used as a return value of the parser functions instead of the previously used bool just showing if the command was found or not in this function.

These are major changes in the communication and require a new GUI version as well.