### PR TITLE
Need to read `cs_pin_num` before setting mode.

### DIFF
--- a/Firmware/FFBoard/Src/ShifterAnalog.cpp
+++ b/Firmware/FFBoard/Src/ShifterAnalog.cpp
@@ -149,9 +149,10 @@ void ShifterAnalog::saveFlash(){
 }
 
 void ShifterAnalog::restoreFlash(){
-	setMode(Flash_Read(ADR_SHIFTERANALOG_CONF, ShifterMode::G29_H));
 	std::tie(x_chan, y_chan) = unpack(Flash_Read(ADR_SHIFTERANALOG_CONF_2, pack(x_chan, y_chan)));
 	std::tie(reverseButtonNum, cs_pin_num) = unpack(Flash_Read(ADR_SHIFTERANALOG_CONF_3, pack(reverseButtonNum, cs_pin_num)));
+
+	setMode(Flash_Read(ADR_SHIFTERANALOG_CONF, ShifterMode::G29_H));
 
 	X_12 = Flash_Read(ADR_SHIFTERANALOG_X_12, X_12);
 	X_56 = Flash_Read(ADR_SHIFTERANALOG_X_56, X_56);


### PR DESCRIPTION
This fixes running the shifter on a CS Pin other than 1. I'd previously tested the selection but until I changed my hardware setup didn't catch that the change didn't apply after a power cycle.