### PR TITLE
Added usb serial to usb interface names & enabled SM2 for disco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 ### Changes this version:
+- Added part of unique serial number to usb interface names for easier identification of multiple devices
+  
+### Changes in 1.12.x:
 - Added support for Simplemotion V2 (Ioni/Argon motor drivers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changes this version:
 - Added part of unique serial number to usb interface names for easier identification of multiple devices
+- Enabled Simplemotion for F407_DISCO build
   
 ### Changes in 1.12.x:
 - Added support for Simplemotion V2 (Ioni/Argon motor drivers)

--- a/Firmware/FFBoard/Inc/USBdevice.h
+++ b/Firmware/FFBoard/Inc/USBdevice.h
@@ -21,10 +21,11 @@
  * This class defines a usb device and implements callbacks for getting the basic
  * usb descriptors for tinyusb.
  * Different usb configurations are predefined in usb_descriptors.c
+ * appendSerial: adds the last n chars of the serial number to the interface strings
  */
 class USBdevice : public cpp_freertos::Thread {
 public:
-	USBdevice(const tusb_desc_device_t* deviceDesc,const uint8_t (*confDesc),const usb_string_desc_t* strings);
+	USBdevice(const tusb_desc_device_t* deviceDesc,const uint8_t (*confDesc),const usb_string_desc_t* strings,uint8_t appendSerial = 4);
 	virtual ~USBdevice();
 	void Run(); // Thread loop
 	void virtual registerUsb();
@@ -38,6 +39,7 @@ protected:
 	const tusb_desc_device_t* desc_device;
 	const uint8_t* desc_conf; // Device configuration descriptor
 	const usb_string_desc_t* string_desc;
+	uint8_t appendSerial;
 };
 
 #endif /* USB_SRC_USBDEVICE_H_ */

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,12,0}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,12,1}; // Version as array. 8 bit each!
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #define FLASH_VERSION 0 // Counter to increase whenever a full flash erase is required.
 

--- a/Firmware/FFBoard/Src/USBdevice.cpp
+++ b/Firmware/FFBoard/Src/USBdevice.cpp
@@ -10,8 +10,8 @@
 
 uint16_t _desc_str[USB_STRING_DESC_BUF_SIZE]; // String buffer
 
-USBdevice::USBdevice(const tusb_desc_device_t* deviceDesc,const uint8_t (*confDesc),const usb_string_desc_t* strings) :
-Thread("USB", 256, 40), desc_device(deviceDesc), desc_conf(confDesc), string_desc(strings) {
+USBdevice::USBdevice(const tusb_desc_device_t* deviceDesc,const uint8_t (*confDesc),const usb_string_desc_t* strings, uint8_t appendSerial) :
+Thread("USB", 256, 40), desc_device(deviceDesc), desc_conf(confDesc), string_desc(strings),appendSerial(appendSerial) {
 
 }
 
@@ -75,6 +75,11 @@ uint16_t* USBdevice::getUsbStringDesc(uint8_t index,uint16_t langid){
 			field = string_desc->manufacturer;
 		}else if(index > 3 && ((index - 4) < (int)string_desc->interfaces.size())){
 			field = string_desc->interfaces[index-4];
+			if(appendSerial){
+				field += "(";
+				field.append(getUsbSerial().substr(0, appendSerial));
+				field += ")";
+			}
 		}else{
 			return NULL;
 		}

--- a/Firmware/Targets/F407VG_DISCO/Core/Inc/target_constants.h
+++ b/Firmware/Targets/F407VG_DISCO/Core/Inc/target_constants.h
@@ -51,6 +51,7 @@
 #define CANBUTTONS // Requires CAN
 #define CANANALOG // Requires CAN
 #define ADS111XANALOG // Requires I2C
+#define SIMPLEMOTION
 
 //#define UARTCOMMANDS
 

--- a/Firmware/Targets/F407VG_DISCO/Core/Src/cpp_target_config.cpp
+++ b/Firmware/Targets/F407VG_DISCO/Core/Src/cpp_target_config.cpp
@@ -31,6 +31,11 @@ extern I2C_HandleTypeDef I2C_PORT;
 I2CPort i2cport{I2C_PORT};
 #endif
 
+#ifdef GPIO_MOTOR
+const OutputPin gpMotor{*DRV_GP1_GPIO_Port,DRV_GP1_Pin};
+#endif
+
+
 #ifdef CANBUS
 /*
  * Can BTR register for different speed configs


### PR DESCRIPTION
This enables simplemotion v2 on the f407_disco build for third party devkits on the same pins as with the normal build.
Also appends by default 4 characters of the usb serial number to any usb interface name so it should show up with a unique name to make identifying multiple devices on the same system easier.