### PR TITLE
Fix torque changed check

### DIFF
--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -702,7 +702,7 @@ bool Axis::updateTorque(int32_t* totalTorque) {
 	metric.current.torque = torque;
 	torque = clip<int32_t, int32_t>(torque, -power, power);
 
-	bool torqueChanged = torque != metric.previous.torque;
+	bool torqueChanged = metric.current.torque != metric.previous.torque;
 
 	if (abs(torque) == power){
 		pulseClipLed();


### PR DESCRIPTION
The torqueChanged might be always true because we compare the clipped current torque with the unclipped previous one.