### PR TITLE
Added UID system command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,15 @@ jobs:
         with:
           path: etc/usr/artifacts/
 
-      # - name: Make temp dir
-      #   run: mkdir -p etc/usr/fw # make temp directory
+      - name: Copy firmware readme
+        run: cp -u ${{ github.workspace }}/Firmware/Targets/README_FIRMWARE.md etc/usr/artifacts/README.md
 
       # # Move hex files
       # - name: Move firmware files
       #   run: find etc/usr/artifacts/ -name '*.hex' -exec cp {} etc/usr/fw/ \;
 
       - name: Zip firmware
-        run: zip -qq -r Firmware.zip OpenFFBoard-Firmware-*
+        run: zip -qq -r Firmware.zip OpenFFBoard-Firmware-* README.md
         working-directory: etc/usr/artifacts/
 
       - name: Zip configurator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Changes this version:
-- Added effect monitoring per axis
+- Added uid command (`sys.uid?` returns first 64 bits as val and second 32 as adr)
  
 ### Changes in 1.13.x
 - Added PWM direction toggle
@@ -8,3 +8,5 @@
 - Added SSI encoder support (AMT232B)
 - Fixed SPI buttons not working (SPI2 DMA on F407)
 - Dynamic TMC encoder alignment current based on current limit
+- Added effect monitoring per axis
+ 

--- a/Firmware/FFBoard/Inc/SystemCommands.h
+++ b/Firmware/FFBoard/Inc/SystemCommands.h
@@ -11,7 +11,7 @@
 #include "CommandHandler.h"
 
 enum class FFBoardMain_commands : uint32_t{
-	help=0,save=1,reboot=2,dfu=3,swver=4,hwtype=5,lsmain,main,lsactive,format,errors,errorsclr,flashdump,flashraw,vint,vext,mallinfo,heapfree,taskstats,debug,devid
+	help=0,save=1,reboot=2,dfu=3,swver=4,hwtype=5,lsmain,main,lsactive,format,errors,errorsclr,flashdump,flashraw,vint,vext,mallinfo,heapfree,taskstats,debug,devid,uid
 };
 
 class SystemCommands : public CommandHandler {

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,13,2}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,13,3}; // Version as array. 8 bit each!
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #define FLASH_VERSION 0 // Counter to increase whenever a full flash erase is required.
 

--- a/Firmware/FFBoard/Src/SystemCommands.cpp
+++ b/Firmware/FFBoard/Src/SystemCommands.cpp
@@ -68,6 +68,7 @@ void SystemCommands::registerCommands(){
 	CommandHandler::registerCommand("devid", FFBoardMain_commands::devid, "Get chip dev id and rev id",CMDFLAG_GET);
 	CommandHandler::registerCommand("name", CommandHandlerCommands::name, "name of class",CMDFLAG_GET|CMDFLAG_STR_ONLY);
 	CommandHandler::registerCommand("cmdinfo", CommandHandlerCommands::cmdinfo, "Flags of a command id (adr). -1 if cmd id invalid",CMDFLAG_GETADR);
+	CommandHandler::registerCommand("uid", FFBoardMain_commands::uid, "Get 96b chip uid. Adr0-2 sel blk",CMDFLAG_GET | CMDFLAG_GETADR);
 }
 
 // Choose lower optimize level because the compiler likes to blow up this function
@@ -265,6 +266,20 @@ CommandStatus SystemCommands::internalCommand(const ParsedCommand& cmd,std::vect
 				HAL_FLASH_Lock();
 			}
 		break;
+		case FFBoardMain_commands::uid:
+			if(cmd.type == CMDtype::get){
+				replies.emplace_back((uint64_t)HAL_GetUIDw0() | (uint64_t)HAL_GetUIDw1() << 32,HAL_GetUIDw2());
+			}else if(cmd.type == CMDtype::getat){
+				if(cmd.adr == 0){
+					replies.emplace_back(HAL_GetUIDw0());
+				}else if(cmd.adr == 1){
+					replies.emplace_back(HAL_GetUIDw1());
+				}else if(cmd.adr == 2){
+					replies.emplace_back(HAL_GetUIDw2());
+				}
+			}
+			break;
+
 
 		default:
 			flag = CommandStatus::NOT_FOUND;

--- a/Firmware/Targets/README_FIRMWARE.md
+++ b/Firmware/Targets/README_FIRMWARE.md
@@ -1,0 +1,16 @@
+## Firmware versions
+
+Use the correct firmware for your board.
+Flashing an incorrect firmware can result in a non working device or even damage to the hardware.
+If you accidentially flashed an incorrect firmware stay in DFU mode (or use ST-link) and do a clean full erase.
+
+Use the .hex file for updates.
+
+The following builds are available:
+
+* F407VG: Official FFBoard 1.2+
+    - Includes all features. Requires VBUS connection
+* F407VG_DISCO: Third party development kits (ST F407 Discovery board, different pin mapping)
+    - See https://github.com/Ultrawipf/OpenFFBoard/wiki/Pinouts-and-peripherals#f407-disco-pinout
+    - No VBUS required
+* F411RE: FFBoard 1.0 (Only supports TMC driver!)


### PR DESCRIPTION
Adds a command that allows reading the full 96bit chip UID.

New command: `sys.uid?` will return first 64 bits as val and second as adr value. (val:adr)
Also allows reading first, second and third 32b part individually by passing the index as address,
Example: `sys.uid?0` gets first 32 bits and `sys.uid?2` last 32 bits.

Also adds a readme file into the firmware release zip with important infos.