### PR TITLE
Changed BUFFER_RX_SIZE to 64

### DIFF
--- a/Firmware/FFBoard/UserExtensions/Inc/VescCAN.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/VescCAN.h
@@ -20,7 +20,7 @@
 #ifdef VESC
 #define VESC_THREAD_MEM 512
 #define VESC_THREAD_PRIO 25 // Must be higher than main thread
-#define BUFFER_RX_SIZE	32
+#define BUFFER_RX_SIZE	64
 
 #define FW_MIN_RELEASE ((5 << 16) | (3 << 8) | 51)
 


### PR DESCRIPTION
OpenFFBoard cannot detect the VESC with long HW_NAME(8 letters upper), because OpenFFBoard drops the longer CAN messages.
Please change the buffer size(easiest way, but not the perfect), or other method which can receive longer CAN messages.