### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
 ### Changes this version:
-- TMC E-Stop handled even during calibration by pausing and disabling driver
-- E-Stop checked correctly after startup. You can now disable force and delay startup by setting E-Stop during startup.
-- Digital and Analog sources are disabled by default
-- Biss-C 1 rotation offset glitch at first packet fixed
-- Reverted CAN retransmission to enabled temporarily. Fixes 2 axis ODrive issues.
-
-### Changes since v1.14.0
-- Save TMC space vector PWM mode in flash. Should be usually on for BLDC motors if the star point is isolated.
-- Allow using the motors flux component to dissipate energy with the TMC4671 instead of the brake resistor. May cause noticable braking in the motor but takes stress off the resistor.
-- Axis speed limiter usable and saved in flash.
-- Removed unused hall direction flash setting.
-- Added local button pulse mode
-- Only activate brake resistor if vint and vext are >6.5V. Prevents board from activating resistor if only usb powered and a fault reset loop
-- Changed behaviour of direction enable and axis enable bits in set_effect report to always apply direction vector
-    - Fix for Forza Motorsport
+- Added independend friction and inertia effects to axis
+- ODrive class can save encoder position offset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 ### Changes this version:
 - Added independend friction and inertia effects to axis
 - ODrive class can save encoder position offset
+- Reverted the forza fix for 2 axis setups. 
+  - TODO: test and report if behaviour works for all games with the angle always being used for 1 axis modes (Games must send 90° on X axis effects instead of 0°).

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,14,5}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,15,0}; // Version as array. 8 bit each!
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #define FLASH_VERSION 0 // Counter to increase whenever a full flash erase is required.
 

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,14,4}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,14,5}; // Version as array. 8 bit each!
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #define FLASH_VERSION 0 // Counter to increase whenever a full flash erase is required.
 

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -9,7 +9,13 @@
  */
 
 static const uint8_t SW_VERSION_INT[3] = {1,15,0}; // Version as array. 8 bit each!
+#ifndef MAX_AXIS
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
+#endif
+#if !(MAX_AXIS > 0 && MAX_AXIS <= 3)
+#error "MAX_AXIS must be between 1 and 3"
+#endif
+
 #define FLASH_VERSION 0 // Counter to increase whenever a full flash erase is required.
 
 //#define DEBUGLOG // Uncomment to enable some debug printouts

--- a/Firmware/FFBoard/Src/AxesManager.cpp
+++ b/Firmware/FFBoard/Src/AxesManager.cpp
@@ -82,8 +82,6 @@ bool AxesManager::setAxisCount(int8_t count) {
 	if (!this->validAxisRange(count)) {
 		return false; // invalid number of axis
 	}
-	// Really need to use some form of mutex
-	Flash_Write(ADR_AXIS_COUNT, count);
 
 	while (count < axis_count) {
 		uint8_t pos = axis_count-1;

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -632,7 +632,6 @@ void Axis::updateMetrics(float new_pos) { // pos is degrees
 	metric.current.accel = accelFilter.process((currentSpeed - _lastSpeed))* 1000.0; // deg/s/s
 	_lastSpeed = currentSpeed;
 
-	metric.current.torque = 0;
 }
 
 

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -898,9 +898,12 @@ CommandStatus Axis::command(const ParsedCommand& cmd,std::vector<CommandReply>& 
 		break;
 
 	case Axis_commands::cpr:
-		if (cmd.type == CMDtype::get && this->drv->getEncoder() != nullptr)
+		if (cmd.type == CMDtype::get)
 		{
-			uint32_t cpr = this->drv->getEncoder()->getCpr();
+			uint32_t cpr = 0;
+			if(this->drv->getEncoder() != nullptr){
+				cpr = this->drv->getEncoder()->getCpr();
+			}
 //#ifdef TMC4671DRIVER // CPR should be consistent with position. Maybe change TMC to prescale to encoder count or correct readout in UI
 //			TMC4671 *tmcdrv = dynamic_cast<TMC4671 *>(this->drv.get()); // Special case for TMC. Get the actual encoder resolution
 //			if (tmcdrv && tmcdrv->hasIntegratedEncoder())

--- a/Firmware/FFBoard/Src/HidFFB.cpp
+++ b/Firmware/FFBoard/Src/HidFFB.cpp
@@ -312,10 +312,21 @@ void HidFFB::set_effect(FFB_SetEffect_t* effect){
 	}
 
 	float phaseX = M_PI*2.0 * (effect->directionX/36000.0);
-	// Angular vector if dirEnable used or axis enabled otherwise 0 if axis disabled
-	effect_p->axisMagnitudes[0] = (directionEnable || (effect->enableAxis & X_AXIS_ENABLE) ? sin(phaseX) : 0);
-	effect_p->axisMagnitudes[1] = (directionEnable || (effect->enableAxis & Y_AXIS_ENABLE) ? cos(phaseX) : 0);
 
+	if(axisCount == 1){
+		/*
+		 * Angular vector if dirEnable used or axis enabled otherwise 0 if axis disabled
+		 * Compatibility fix.
+		 * Some single axis games send no directionEnable but enableAxis but still use phase vectors to scale a single axis effect
+		 */
+		effect_p->axisMagnitudes[0] = (directionEnable || (effect->enableAxis & X_AXIS_ENABLE) ? sin(phaseX) : 0);
+	}else{
+		/*
+		 * Some 2 axis games send no vector and require the axis to be enable via enableAxis
+		 */
+		effect_p->axisMagnitudes[0] = directionEnable ? sin(phaseX) : (effect->enableAxis & X_AXIS_ENABLE ? 1 : 0); // Angular vector if dirEnable used otherwise full or 0 if axis enabled
+		effect_p->axisMagnitudes[1] = directionEnable ? cos(phaseX) : (effect->enableAxis & Y_AXIS_ENABLE ? 1 : 0); // Angular vector if
+	}
 
 #if MAX_AXIS == 3
 	float phaseY = M_PI*2.0 * (effect->directionY/36000.0);

--- a/Firmware/FFBoard/Src/SystemCommands.cpp
+++ b/Firmware/FFBoard/Src/SystemCommands.cpp
@@ -55,7 +55,7 @@ void SystemCommands::registerCommands(){
 	CommandHandler::registerCommand("main", FFBoardMain_commands::main, "Query or change mainclass",CMDFLAG_GET | CMDFLAG_SET);
 	CommandHandler::registerCommand("swver", FFBoardMain_commands::swver, "Firmware version",CMDFLAG_GET);
 	CommandHandler::registerCommand("hwtype", FFBoardMain_commands::hwtype, "Hardware type",CMDFLAG_GET);
-	CommandHandler::registerCommand("flashraw", FFBoardMain_commands::flashraw, "Write value to flash address",CMDFLAG_SETADR);
+	CommandHandler::registerCommand("flashraw", FFBoardMain_commands::flashraw, "Write value to flash address",CMDFLAG_SETADR | CMDFLAG_GETADR);
 	CommandHandler::registerCommand("flashdump", FFBoardMain_commands::flashdump, "Read all flash variables (val:adr)",CMDFLAG_GET);
 	CommandHandler::registerCommand("errors", FFBoardMain_commands::errors, "Read error states",CMDFLAG_GET);
 	CommandHandler::registerCommand("errorsclr", FFBoardMain_commands::errorsclr, "Reset errors",CMDFLAG_GET);

--- a/Firmware/FFBoard/Src/USBdevice.cpp
+++ b/Firmware/FFBoard/Src/USBdevice.cpp
@@ -33,8 +33,7 @@ void USBdevice::registerUsb(){
 void USBdevice::Run(){
 	tusb_init();
 	while(1){
-		tud_task();
-		Delay(1);
+		tud_task(); // Run until no usb events left
 	}
 }
 

--- a/Firmware/FFBoard/UserExtensions/Inc/ODriveCAN.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/ODriveCAN.h
@@ -29,7 +29,7 @@ enum class ODriveEncoderFlags : uint32_t {ERROR_NONE = 0,ERROR_UNSTABLE_GAIN = 0
 enum class ODriveAxisError : uint32_t {AXIS_ERROR_NONE = 0x00000000,AXIS_ERROR_INVALID_STATE  = 0x00000001, AXIS_ERROR_WATCHDOG_TIMER_EXPIRED = 0x00000800,AXIS_ERROR_MIN_ENDSTOP_PRESSED = 0x00001000, AXIS_ERROR_MAX_ENDSTOP_PRESSED = 0x00002000,AXIS_ERROR_ESTOP_REQUESTED = 0x00004000,AXIS_ERROR_HOMING_WITHOUT_ENDSTOP = 0x00020000,AXIS_ERROR_OVER_TEMP = 0x00040000,AXIS_ERROR_UNKNOWN_POSITION = 0x00080000};
 
 enum class ODriveCAN_commands : uint32_t{
-	canid,canspd,errors,state,maxtorque,vbus,anticogging,connected
+	canid,canspd,errors,state,maxtorque,vbus,anticogging,connected,storepos
 };
 
 class ODriveCAN : public MotorDriver,public PersistentStorage, public Encoder, public CanHandler, public CommandHandler, cpp_freertos::Thread{
@@ -106,6 +106,7 @@ private:
 
 	uint32_t lastPosTime = 0;
 	bool posWaiting = false;
+	bool reloadPosAfterStartup = false;
 
 	int8_t nodeId = 0; // 6 bits can ID
 	int8_t motorId = 0;

--- a/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
@@ -13,11 +13,11 @@
 
 #include "main.h"
 // Change this to the amount of currently registered variables
-#define NB_OF_VAR 148
+#define NB_OF_VAR 150
 extern const uint16_t VirtAddVarTab[NB_OF_VAR];
 
 // Amount of variables in exportable list
-#define NB_EXPORTABLE_ADR 133
+#define NB_EXPORTABLE_ADR 135
 extern const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR];
 
 
@@ -165,6 +165,8 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_ODRIVE_CANID 0x3D0 //0-6 ID M0, 7-12 ID M1, 13-15 can speed
 #define ADR_ODRIVE_SETTING1_M0 0x3D1
 #define ADR_ODRIVE_SETTING1_M1 0x3D2
+#define ADR_ODRIVE_OFS_M0 0x3D3 // Encoder offset position reload
+#define ADR_ODRIVE_OFS_M1 0x3D4
 // VESC Section
 #define ADR_VESC1_CANID 0x3E0 //0-7 AxisCanID, 8-16 VescCanId
 #define ADR_VESC1_DATA 0x3E1 //0-2 can speed, 3 useVescEncoder

--- a/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
@@ -13,11 +13,11 @@
 
 #include "main.h"
 // Change this to the amount of currently registered variables
-#define NB_OF_VAR 150
+#define NB_OF_VAR 153
 extern const uint16_t VirtAddVarTab[NB_OF_VAR];
 
 // Amount of variables in exportable list
-#define NB_EXPORTABLE_ADR 135
+#define NB_EXPORTABLE_ADR 138
 extern const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR];
 
 
@@ -99,6 +99,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS1_EFFECTS1 0x308 // 0-7 idlespring, 8-15 damper
 #define ADR_AXIS1_SPEEDACCEL_FILTER 0x309 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS1_ENC_RATIO 0x30A // Accel filter Lowpass
+#define ADR_AXIS1_EFFECTS2 0x30B // 0-7 Friction, 8-15 Inertia
 // TMC1
 #define ADR_TMC1_MOTCONF 0x320 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC1_CPR 0x321
@@ -123,6 +124,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS2_EFFECTS1 0x348 // 0-7 idlespring, 8-15 damper
 #define ADR_AXIS2_SPEEDACCEL_FILTER 0x349 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS2_ENC_RATIO 0x34A // Store the encoder ratio for an axis
+#define ADR_AXIS2_EFFECTS2 0x34B // 0-7 Friction, 8-15 Inertia
 // TMC2
 #define ADR_TMC2_MOTCONF 0x360 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC2_CPR 0x361
@@ -147,6 +149,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS3_EFFECTS1 0x388 // 0-7 idlespring, 8-15 damper
 #define ADR_AXIS3_SPEEDACCEL_FILTER 0x389 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS3_ENC_RATIO 0x38A // Store the encoder ratio for an axis
+#define ADR_AXIS3_EFFECTS2 0x38B // 0-7 Friction, 8-15 Inertia
 // TMC3
 #define ADR_TMC3_MOTCONF 0x3A0 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC3_CPR 0x3A1

--- a/Firmware/FFBoard/UserExtensions/Src/ODriveCAN.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/ODriveCAN.cpp
@@ -171,7 +171,7 @@ void ODriveCAN::Run(){
 			// Odrive is active,
 			// enable torque mode
 			if(odriveCurrentState == ODriveState::AXIS_STATE_CLOSED_LOOP_CONTROL){
-				this->setPos(0);
+				//this->setPos(0);
 				setMode(ODriveControlMode::CONTROL_MODE_TORQUE_CONTROL, ODriveInputMode::INPUT_MODE_PASSTHROUGH);
 			}
 

--- a/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
+++ b/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
@@ -81,6 +81,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS1_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS1_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS1_ENC_RATIO, // Accel filter Lowpass
+	ADR_AXIS1_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC1
 	ADR_TMC1_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC1_CPR,
@@ -105,6 +106,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS2_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS2_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS2_ENC_RATIO, // Store the encoder ratio for an axis
+	ADR_AXIS2_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC2
 	ADR_TMC2_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC2_CPR,
@@ -129,6 +131,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS3_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS3_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS3_ENC_RATIO, // Store the encoder ratio for an axis
+	ADR_AXIS3_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC3
 	ADR_TMC3_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC3_CPR,
@@ -264,6 +267,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS1_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS1_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS1_ENC_RATIO, // Accel filter Lowpass
+	ADR_AXIS1_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC1
 	ADR_TMC1_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC1_CPR,
@@ -288,6 +292,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS2_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS2_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS2_ENC_RATIO, // Store the encoder ratio for an axis
+	ADR_AXIS2_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC2
 	ADR_TMC2_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC2_CPR,
@@ -312,6 +317,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS3_EFFECTS1, // 0-7 idlespring, 8-15 damper
 	ADR_AXIS3_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS3_ENC_RATIO, // Store the encoder ratio for an axis
+	ADR_AXIS3_EFFECTS2, // 0-7 Friction, 8-15 Inertia
 // TMC3
 	ADR_TMC3_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC3_CPR,

--- a/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
+++ b/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
@@ -147,6 +147,8 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_ODRIVE_CANID, //0-6 ID M0, 7-12 ID M1, 13-15 can speed
 	ADR_ODRIVE_SETTING1_M0,
 	ADR_ODRIVE_SETTING1_M1,
+	ADR_ODRIVE_OFS_M0, // Encoder offset position reload
+	ADR_ODRIVE_OFS_M1,
 // VESC Section
 	ADR_VESC1_CANID, //0-7 AxisCanID, 8-16 VescCanId
 	ADR_VESC1_DATA, //0-2 can speed, 3 useVescEncoder
@@ -328,6 +330,8 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_ODRIVE_CANID, //0-6 ID M0, 7-12 ID M1, 13-15 can speed
 	ADR_ODRIVE_SETTING1_M0,
 	ADR_ODRIVE_SETTING1_M1,
+	ADR_ODRIVE_OFS_M0, // Encoder offset position reload
+	ADR_ODRIVE_OFS_M1,
 // VESC Section
 	ADR_VESC1_CANID, //0-7 AxisCanID, 8-16 VescCanId
 	ADR_VESC1_DATA, //0-2 can speed, 3 useVescEncoder

--- a/Firmware/scripts/memory_map.csv
+++ b/Firmware/scripts/memory_map.csv
@@ -63,6 +63,7 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS1_EFFECTS1,0x308,"// 0-7 idlespring, 8-15 damper",1,1
 ,ADR_AXIS1_SPEEDACCEL_FILTER,0x309,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS1_ENC_RATIO,0x30A,// Accel filter Lowpass,1,1
+,ADR_AXIS1_EFFECTS2,0x30B,"// 0-7 Friction, 8-15 Inertia",1,1
 // TMC1,,,,,
 ,ADR_TMC1_MOTCONF,0x320,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC1_CPR,0x321,,1,1
@@ -87,6 +88,7 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS2_EFFECTS1,0x348,"// 0-7 idlespring, 8-15 damper",1,1
 ,ADR_AXIS2_SPEEDACCEL_FILTER,0x349,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS2_ENC_RATIO,0x34A,// Store the encoder ratio for an axis,1,1
+,ADR_AXIS2_EFFECTS2,0x34B,"// 0-7 Friction, 8-15 Inertia",1,1
 // TMC2,,,,,
 ,ADR_TMC2_MOTCONF,0x360,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC2_CPR,0x361,,1,1
@@ -111,6 +113,7 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS3_EFFECTS1,0x388,"// 0-7 idlespring, 8-15 damper",1,1
 ,ADR_AXIS3_SPEEDACCEL_FILTER,0x389,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS3_ENC_RATIO,0x38A,// Store the encoder ratio for an axis,1,1
+,ADR_AXIS3_EFFECTS2,0x38B,"// 0-7 Friction, 8-15 Inertia",1,1
 // TMC3,,,,,
 ,ADR_TMC3_MOTCONF,0x3A0,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC3_CPR,0x3A1,,1,1

--- a/Firmware/scripts/memory_map.csv
+++ b/Firmware/scripts/memory_map.csv
@@ -129,6 +129,8 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_ODRIVE_CANID,0x3D0,"//0-6 ID M0, 7-12 ID M1, 13-15 can speed",1,1
 ,ADR_ODRIVE_SETTING1_M0,0x3D1,,1,1
 ,ADR_ODRIVE_SETTING1_M1,0x3D2,,1,1
+,ADR_ODRIVE_OFS_M0,0x3D3,// Encoder offset position reload,1,1
+,ADR_ODRIVE_OFS_M1,0x3D4,,1,1
 // VESC Section,,,,,
 ,ADR_VESC1_CANID,0x3E0,"//0-7 AxisCanID, 8-16 VescCanId",1,1
 ,ADR_VESC1_DATA,0x3E1,"//0-2 can speed, 3 useVescEncoder",1,1


### PR DESCRIPTION
### Changes this version:
- Added independend friction and inertia effects to axis
- ODrive class can save encoder position offset
- Reverted the forza fix for 2 axis setups. 
  - TODO: test and report if behaviour works for all games with the angle always being used for 1 axis modes (Games must send 90° on X axis effects instead of 0°).

Also improves usb delay under high load of commands and fixes a glitch in the GUI effect live view where the total output torque may sometimes jump to 0.

New effects may require some retuning in future releases.