### PR TITLE
Bugfix: modify return type of getIntV() and getExtV() to int32_t

### DIFF
--- a/Firmware/FFBoard/Inc/voltagesense.h
+++ b/Firmware/FFBoard/Inc/voltagesense.h
@@ -9,8 +9,8 @@
 #define VOLTAGESENSE_H_
 #include "target_constants.h"
 
-uint16_t getIntV();
-uint16_t getExtV();
+int32_t getIntV();
+int32_t getExtV();
 void brakeCheck();
 
 /*

--- a/Firmware/FFBoard/Src/SerialFFB.cpp
+++ b/Firmware/FFBoard/Src/SerialFFB.cpp
@@ -74,7 +74,7 @@ void SerialFFB::set_gain(uint8_t gain){
  * Returns the index where the effect was created or -1 if it can not be created
  */
 int32_t SerialFFB::newEffect(uint8_t effectType){
-	uint32_t idx = this->effects_calc->find_free_effect(effectType);
+	int32_t idx = this->effects_calc->find_free_effect(effectType);
 	if(idx >= 0){
 		// Allocate effect
 		effects[idx].type = effectType;

--- a/Firmware/FFBoard/Src/voltagesense.cpp
+++ b/Firmware/FFBoard/Src/voltagesense.cpp
@@ -41,11 +41,11 @@ void setupBrakePin(uint32_t vdiffAct,uint32_t vdiffDeact,uint32_t vMax){
 	voltageDiffDeactivate = vdiffDeact;
 }
 
-uint16_t getIntV(){
+int32_t getIntV(){
 	return VSENSE_ADC_BUF[ADC_CHAN_VINT] * vSenseMult;
 }
 
-uint16_t getExtV(){
+int32_t getExtV(){
 	return VSENSE_ADC_BUF[ADC_CHAN_VEXT] * vSenseMult;
 }
 
@@ -53,8 +53,8 @@ void brakeCheck(){
 	if(maxVoltage == 0 || brake_failure){
 		return;
 	}
-	uint16_t vint = getIntV();
-	uint16_t vext = getExtV();
+	int32_t vint = getIntV();
+	int32_t vext = getExtV();
 
 	if(vint < minVoltage && vext < minVoltage){
 		return; // Do not enable if device is unpowered (just measuring usb leakage)

--- a/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
@@ -186,7 +186,7 @@ void TMC4671::restoreFlash(){
 }
 
 bool TMC4671::hasPower(){
-	uint16_t intV = getIntV();
+	int32_t intV = getIntV();
 	return (intV > 10000) && (getExtV() > 10000) && (intV < 78000);
 }
 


### PR DESCRIPTION
As shown in the following code, since the range of the data type `uint16_t` cannot express numbers greater than `78000`, there is a comparison that is always true.
``` c
bool TMC4671::hasPower(){
	uint16_t intV = getIntV();
	return (intV > 10000) && (getExtV() > 10000) && (intV < 78000);
}
```

Therefore, the return type of getExtV() and getIntV() has been changed to int32_t
