### PR TITLE
Release v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 - Standardized encoder counting direction counting up in CCW direction as a more common industrial standard
 - Fixed idle spring effect not working before first save
 - Retuned speed limiter function. Removed averaging. Should be more stable for high resolution encoders if high bandwidth speed filter preset is selected
+- Force ramps up slowly on potential sharp position changes such as recentering
+- FFB led now shows FFB state. On when FFB actuators enabled. Still blinks on clipping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Changes this version:
-- Added independend friction and inertia effects to axis
-- ODrive class can save encoder position offset
-- Reverted the forza fix for 2 axis setups. 
-  - TODO: test and report if behaviour works for all games with the angle always being used for 1 axis modes (Games must send 90° on X axis effects instead of 0°).
+- Fixed BISS-C encoder sometimes overflowing one rotation at startup
+- Added BISS-C direction inversion function (Default true). Most BISS-C encoders count CW while most others and TMC count CCW.
+- Standardized encoder counting direction counting up in CCW direction as a more common industrial standard
+- Fixed idle spring effect not working before first save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Added BISS-C direction inversion function (Default true). Most BISS-C encoders count CW while most others and TMC count CCW.
 - Standardized encoder counting direction counting up in CCW direction as a more common industrial standard
 - Fixed idle spring effect not working before first save
+- Retuned speed limiter function. Removed averaging. Should be more stable for high resolution encoders if high bandwidth speed filter preset is selected

--- a/Firmware/FFBoard/Inc/AnalogSource.h
+++ b/Firmware/FFBoard/Inc/AnalogSource.h
@@ -30,7 +30,7 @@ public:
 	virtual std::vector<int32_t>* getAxes();
 	std::vector<int32_t> buf;
 
-
+	static const std::vector<class_entry<AnalogSource>> all_analogsources;
 
 private:
 

--- a/Firmware/FFBoard/Inc/Axis.h
+++ b/Firmware/FFBoard/Inc/Axis.h
@@ -154,6 +154,8 @@ public:
 	int32_t getTorque(); // current torque scaled as a 32 bit signed value
 	int16_t updateEndstop();
 
+	void startForceFadeIn(float start = 0,float fadeTime = 0.5);
+
 	metric_t* getMetrics();
 
 	void setEffectTorque(int32_t torque);
@@ -184,6 +186,9 @@ private:
 	static uint16_t encodeConfToInt(AxisConfig conf);
 
 	const Error outOfBoundsError = Error(ErrorCode::axisOutOfRange,ErrorType::warning,"Axis out of bounds");
+
+	float forceFadeTime = 1.0;
+	float forceFadeCurMult = 1.0;
 
 #ifdef TMC4671DRIVER
 	TMC4671Limits tmclimits = TMC4671Limits({.pid_torque_flux_ddt = 32767,
@@ -253,6 +258,7 @@ private:
 	int16_t idlespringclip = 0;
 	float idlespringscale = 0;
 	bool idle_center = false;
+	bool motorWasNotReady = true;
 
 	// TODO tune these and check if it is really stable and beneficial to the FFB. index 4 placeholder
 	const biquad_constant_t filterSpeedCst[4] = {{ 30, 55 }, { 60, 55 }, { 120, 55 }, {120, 55}};

--- a/Firmware/FFBoard/Inc/Axis.h
+++ b/Firmware/FFBoard/Inc/Axis.h
@@ -257,7 +257,6 @@ private:
 	uint8_t idlespringstrength = 127;
 	int16_t idlespringclip = 0;
 	float idlespringscale = 0;
-	bool idle_center = true;
 	bool motorWasNotReady = true;
 
 	// TODO tune these and check if it is really stable and beneficial to the FFB. index 4 placeholder

--- a/Firmware/FFBoard/Inc/Axis.h
+++ b/Firmware/FFBoard/Inc/Axis.h
@@ -249,7 +249,7 @@ private:
 	uint16_t power = 5000;
 	float torqueScaler = 0; // power * fx_ratio as a ratio between 0 & 1
 	float effect_margin_scaler = 0;
-	bool invertAxis = false;
+	bool invertAxis = true; // By default most motors and encoders count up CCW while gamepads are counting up CW.
 	uint8_t endstopStrength = 127; // Sets how much extra torque per count above endstop is added. High = stiff endstop. Low = softer
 	const float endstopGain = 25; // Overall max endstop intensity
 
@@ -257,7 +257,7 @@ private:
 	uint8_t idlespringstrength = 127;
 	int16_t idlespringclip = 0;
 	float idlespringscale = 0;
-	bool idle_center = false;
+	bool idle_center = true;
 	bool motorWasNotReady = true;
 
 	// TODO tune these and check if it is really stable and beneficial to the FFB. index 4 placeholder

--- a/Firmware/FFBoard/Inc/ButtonSource.h
+++ b/Firmware/FFBoard/Inc/ButtonSource.h
@@ -11,7 +11,7 @@
 #include "cppmain.h"
 #include "ChoosableClass.h"
 #include "PersistentStorage.h"
-
+#include "vector"
 
 /**
  * A button source can return up to 64 buttons
@@ -31,6 +31,8 @@ public:
 	static ClassIdentifier info;
 	static bool isCreatable() {return true;};
 	virtual const ClassType getClassType() {return ClassType::Buttonsource;};
+
+	static const std::vector<class_entry<ButtonSource> > all_buttonsources;
 
 protected:
 	uint16_t btnnum = 0; // Amount of active buttons (valid bitfield length) to report

--- a/Firmware/FFBoard/Inc/Encoder.h
+++ b/Firmware/FFBoard/Inc/Encoder.h
@@ -12,12 +12,10 @@
 #include "ChoosableClass.h"
 
 /*
- * Info about used ids:
- * 0: none
- * 1: tmc reserved
- * 2: local/tmc1
- * 3: tmc3
- * 4: mt encoder
+ * Note:
+ * Encoders should count UP when turned counterclockwise
+ * This is not the default gamepad direction but matches most motors
+ * If direction is not fixed the encoder class should provide a reverse option
  */
 
 /*

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,15,0}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,15,1}; // Version as array. 8 bit each!
 #ifndef MAX_AXIS
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #endif

--- a/Firmware/FFBoard/Inc/ledEffects.h
+++ b/Firmware/FFBoard/Inc/ledEffects.h
@@ -14,6 +14,7 @@ typedef struct Ledstruct{
 	int32_t blinks;
 	GPIO_TypeDef* port;
 	uint16_t pin;
+	uint8_t state;
 } Ledstruct_t;
 
 
@@ -28,6 +29,11 @@ void blinkClipLed(uint16_t period,uint16_t blinks);
 
 void updateLed(Ledstruct_t* led);
 void updateLeds();
+
+void setLed(Ledstruct_t* led,uint8_t on);
+void setClipLed(uint8_t on);
+void setErrLed(uint8_t on);
+void setSysLed(uint8_t on);
 
 
 #endif /* LEDEFFECTS_H_ */

--- a/Firmware/FFBoard/Inc/voltagesense.h
+++ b/Firmware/FFBoard/Inc/voltagesense.h
@@ -9,8 +9,8 @@
 #define VOLTAGESENSE_H_
 #include "target_constants.h"
 
-uint16_t getIntV();
-uint16_t getExtV();
+int32_t getIntV();
+int32_t getExtV();
 void brakeCheck();
 
 /*

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -203,6 +203,8 @@ void Axis::restoreFlash(){
 	if(Flash_Read(flashAddrs.effects1, &effects)){
 		setIdleSpringStrength(effects & 0xff);
 		setFxStrengthAndFilter((effects >> 8) & 0xff,damperIntensity,damperFilter);
+	}else{
+		setIdleSpringStrength(idlespringstrength); // Use default
 	}
 
 	if(Flash_Read(flashAddrs.effects2, &effects)){
@@ -547,11 +549,6 @@ int32_t Axis::updateIdleSpringForce() {
  */
 void Axis::setIdleSpringStrength(uint8_t spring){
 	idlespringstrength = spring;
-	if(spring == 0){
-		idle_center = false;
-	}else{
-		idle_center = true;
-	}
 	idlespringclip = clip<int32_t,int32_t>((int32_t)spring*35,0,10000);
 	idlespringscale = 0.5f + ((float)spring * 0.01f);
 }

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -705,9 +705,9 @@ bool Axis::updateTorque(int32_t* totalTorque) {
 
 		float torqueSign = torque > 0 ? 1 : -1; // Used to prevent metrics against the force to go into the limiter
 		// Speed. Mostly tuned...
-		spdlimiterAvg.addValue(metric.current.speed);
-		float speedreducer = (float)((spdlimiterAvg.getAverage()*torqueSign) - (float)maxSpeedDegS) *  ((float)0x7FFF / maxSpeedDegS);
-		spdlimitreducerI = clip<float,int32_t>( spdlimitreducerI + ((speedreducer * 0.015) * torqueScaler),0,power);
+		//spdlimiterAvg.addValue(metric.current.speed);
+		float speedreducer = (float)((metric.current.speed*torqueSign) - (float)maxSpeedDegS) *  ((float)0x7FFF / maxSpeedDegS);
+		spdlimitreducerI = clip<float,int32_t>( spdlimitreducerI + ((speedreducer * speedLimiterI) * torqueScaler),0,power);
 
 		// Accel limit. Not really useful. Maybe replace with torque slew rate limit?
 //		float accreducer = (float)((metric.current.accel*torqueSign) - (float)maxAccelDegSS) * getAccelScalerNormalized();
@@ -949,7 +949,7 @@ CommandStatus Axis::command(const ParsedCommand& cmd,std::vector<CommandReply>& 
 		}
 		else if (cmd.type == CMDtype::set)
 		{
-			uint32_t value = clip<uint32_t, uint32_t>(cmd.val, 0, 2);
+			uint32_t value = clip<uint32_t, uint32_t>(cmd.val, 0, filterSpeedCst.size()-1);
 			this->filterProfileId = value;
 			speedFilter.setFc(filterSpeedCst[this->filterProfileId].freq / filter_f);
 			speedFilter.setQ(filterSpeedCst[this->filterProfileId].q / 100.0);

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -664,7 +664,7 @@ float Axis::getTorqueScaler(){
 int32_t Axis::getTorque() { return metric.current.torque; }
 
 bool Axis::isInverted() {
-	return invertAxis; // TODO store in flash
+	return invertAxis;
 }
 
 /**
@@ -895,11 +895,12 @@ CommandStatus Axis::command(const ParsedCommand& cmd,std::vector<CommandReply>& 
 	case Axis_commands::pos:
 		if (cmd.type == CMDtype::get && this->drv->getEncoder() != nullptr)
 		{
-			replies.emplace_back(this->drv->getEncoder()->getPos());
+			int32_t pos = this->drv->getEncoder()->getPos();
+			replies.emplace_back(isInverted() ? -pos : pos);
 		}
 		else if (cmd.type == CMDtype::set && this->drv->getEncoder() != nullptr)
 		{
-			this->drv->getEncoder()->setPos(cmd.val);
+			this->drv->getEncoder()->setPos(isInverted() ? -cmd.val : cmd.val);
 		}
 		else
 		{

--- a/Firmware/FFBoard/Src/EffectsCalculator.cpp
+++ b/Firmware/FFBoard/Src/EffectsCalculator.cpp
@@ -9,7 +9,7 @@
 #include <math.h>
 #include "EffectsCalculator.h"
 #include "Axis.h"
-
+#include "ledEffects.h"
 
 
 #define EFFECT_STATE_INACTIVE 0
@@ -71,6 +71,7 @@ void EffectsCalculator::setActive(bool active)
 		effects_stats[i].current = {0}; // Reset active effect forces
 		effects_statslast[i].current = {0};
 	}
+	setClipLed(active);
 }
 
 

--- a/Firmware/FFBoard/Src/Encoder.cpp
+++ b/Firmware/FFBoard/Src/Encoder.cpp
@@ -7,30 +7,6 @@
 
 #include "Encoder.h"
 #include "ClassChooser.h"
-#include "EncoderLocal.h"
-#include "MtEncoderSPI.h"
-#include "EncoderBissC.h"
-#include "EncoderSSI.h"
-// 0-63 valid ids
-std::vector<class_entry<Encoder>> const Encoder::all_encoders =
-	{
-		add_class<Encoder, Encoder>(0),
-
-#ifdef LOCALENCODER
-		add_class<EncoderLocal, Encoder>(2),
-#endif
-
-#ifdef MTENCODERSPI
-		add_class<MtEncoderSPI, Encoder>(4),
-#endif
-#ifdef BISSENCODER
-		add_class<EncoderBissC, Encoder>(5),
-#endif
-#ifdef SSIENCODER
-		add_class<EncoderSSI, Encoder>(6),
-#endif
-
-};
 
 ClassIdentifier Encoder::info ={.name = "None" , .id=CLSID_ENCODER_NONE, .visibility = ClassVisibility::visible};
 

--- a/Firmware/FFBoard/Src/SerialFFB.cpp
+++ b/Firmware/FFBoard/Src/SerialFFB.cpp
@@ -74,7 +74,7 @@ void SerialFFB::set_gain(uint8_t gain){
  * Returns the index where the effect was created or -1 if it can not be created
  */
 int32_t SerialFFB::newEffect(uint8_t effectType){
-	uint32_t idx = this->effects_calc->find_free_effect(effectType);
+	int32_t idx = this->effects_calc->find_free_effect(effectType);
 	if(idx >= 0){
 		// Allocate effect
 		effects[idx].type = effectType;

--- a/Firmware/FFBoard/Src/ledEffects.cpp
+++ b/Firmware/FFBoard/Src/ledEffects.cpp
@@ -8,13 +8,13 @@
 #include "main.h"
 
 Ledstruct_t sysled{
-	0,0,0,LED_SYS_GPIO_Port,LED_SYS_Pin
+	0,0,0,LED_SYS_GPIO_Port,LED_SYS_Pin,0
 };
 Ledstruct_t errled{
-	0,0,0,LED_ERR_GPIO_Port,LED_ERR_Pin
+	0,0,0,LED_ERR_GPIO_Port,LED_ERR_Pin,0
 };
 Ledstruct_t clipled{
-	0,0,0,LED_CLIP_GPIO_Port,LED_CLIP_Pin
+	0,0,0,LED_CLIP_GPIO_Port,LED_CLIP_Pin,0
 };
 
 /**
@@ -27,12 +27,12 @@ void blinkLed(Ledstruct* led,uint16_t period,uint16_t blinks){
 	if(period == 0 && blinks == 0){
 		led->blinks = 0;
 		led->period = 0;
-		HAL_GPIO_WritePin(led->port, led->pin, GPIO_PIN_RESET);
+		HAL_GPIO_WritePin(led->port, led->pin, led->state ? GPIO_PIN_SET : GPIO_PIN_RESET);
 	}else{
 		led->blinks = (blinks * 2) -1;
 		led->period = period;
 		led->tick = HAL_GetTick();
-		HAL_GPIO_WritePin(led->port, led->pin, GPIO_PIN_SET);
+		HAL_GPIO_WritePin(led->port, led->pin, led->state ? GPIO_PIN_RESET : GPIO_PIN_SET);
 	}
 }
 
@@ -62,12 +62,29 @@ void blinkClipLed(uint16_t period,uint16_t blinks){
 	blinkLed(&clipled, period, blinks);
 }
 
+void setLed(Ledstruct_t* led,uint8_t on){
+	led->state = on;
+	HAL_GPIO_WritePin(led->port, led->pin, led->state ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}
+
+void setClipLed(uint8_t on){
+	setLed(&clipled,on);
+}
+
+void setErrLed(uint8_t on){
+	setLed(&errled,on);
+}
+
+void setSysLed(uint8_t on){
+	setLed(&sysled,on);
+}
+
 
 void updateLed(Ledstruct* led){
 	// If led has an effect (period != 0) and time is up do something
 	if(led->period != 0 && HAL_GetTick() > led->tick+led->period){
 		if(led->blinks == 0){ // No blinks left. turn off
-			HAL_GPIO_WritePin(led->port, led->pin, GPIO_PIN_RESET);
+			HAL_GPIO_WritePin(led->port, led->pin, led->state ? GPIO_PIN_SET : GPIO_PIN_RESET);
 			led->period = 0;
 		}else{
 			led->tick = HAL_GetTick();

--- a/Firmware/FFBoard/Src/voltagesense.cpp
+++ b/Firmware/FFBoard/Src/voltagesense.cpp
@@ -41,11 +41,11 @@ void setupBrakePin(uint32_t vdiffAct,uint32_t vdiffDeact,uint32_t vMax){
 	voltageDiffDeactivate = vdiffDeact;
 }
 
-uint16_t getIntV(){
+int32_t getIntV(){
 	return VSENSE_ADC_BUF[ADC_CHAN_VINT] * vSenseMult;
 }
 
-uint16_t getExtV(){
+int32_t getExtV(){
 	return VSENSE_ADC_BUF[ADC_CHAN_VEXT] * vSenseMult;
 }
 
@@ -53,8 +53,8 @@ void brakeCheck(){
 	if(maxVoltage == 0 || brake_failure){
 		return;
 	}
-	uint16_t vint = getIntV();
-	uint16_t vext = getExtV();
+	int32_t vint = getIntV();
+	int32_t vext = getExtV();
 
 	if(vint < minVoltage && vext < minVoltage){
 		return; // Do not enable if device is unpowered (just measuring usb leakage)

--- a/Firmware/FFBoard/UserExtensions/Inc/EncoderBissC.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/EncoderBissC.h
@@ -42,7 +42,7 @@ public:
 
 	void Run();
 
-	enum class EncoderBissC_commands {bits,cs,speed,errors};
+	enum class EncoderBissC_commands {bits,cs,speed,errors,direction};
 
 	CommandStatus command(const ParsedCommand& cmd,std::vector<CommandReply>& replies);
 
@@ -59,6 +59,7 @@ private:
 	int lenghtDataBit = 22;
 	int spiSpeed = 3;
 	bool waitData = false;
+	bool invertDirection = true; // Most biss-c encoders count UP clockwise while standard motor direction is usually CCW
 
 	uint32_t lastUpdateTick = 0;
 

--- a/Firmware/FFBoard/UserExtensions/Inc/TMC4671.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/TMC4671.h
@@ -458,6 +458,8 @@ public:
 	int32_t getActualFlux();
 	int32_t getActualTorque();
 
+	void rampFlux(uint16_t target,uint16_t time_ms);
+
 	bool checkAdc();
 
 	float getTemp();

--- a/Firmware/FFBoard/UserExtensions/Src/AnalogSources.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/AnalogSources.cpp
@@ -1,0 +1,27 @@
+/*
+ * AnalogSources.cpp
+ *
+ *  Created on: Apr 18, 2024
+ *      Author: Yannick
+ */
+
+#include "constants.h"
+#include "LocalAnalog.h"
+#include "CanAnalog.h"
+#include "ADS111X.h"
+
+// Register possible analog sources (id 0-15)
+#ifndef ANALOGSOURCES_DEFAULT_OVERRIDE
+const std::vector<class_entry<AnalogSource>> AnalogSource::all_analogsources =
+{
+#ifdef ANALOGAXES
+		add_class<LocalAnalog,AnalogSource>(0),
+#endif
+#ifdef CANANALOG
+		add_class<CanAnalog<8>,AnalogSource>(1),
+#endif
+#ifdef ADS111XANALOG
+		add_class<ADS111X_AnalogSource,AnalogSource>(2),
+#endif
+};
+#endif

--- a/Firmware/FFBoard/UserExtensions/Src/ButtonSources.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/ButtonSources.cpp
@@ -1,0 +1,37 @@
+/*
+ * ButtonSources.cpp
+ *
+ *  Created on: Apr 18, 2024
+ *      Author: Yannick
+ */
+#include "constants.h"
+#include "SPIButtons.h"
+#include "CanButtons.h"
+#include "LocalButtons.h"
+#include <ShifterAnalog.h>
+#include "PCF8574.h"
+
+#ifndef BUTTONSOURCES_DEFAULT_OVERRIDE
+// Register possible button sources (id 0-15)
+const std::vector<class_entry<ButtonSource>> ButtonSource::all_buttonsources =
+{
+#ifdef LOCALBUTTONS
+		add_class<LocalButtons,ButtonSource>(0),
+#endif
+#ifdef SPIBUTTONS
+		add_class<SPI_Buttons_1,ButtonSource>(1),
+#endif
+#ifdef SPIBUTTONS2
+		add_class<SPI_Buttons_2,ButtonSource>(2),
+#endif
+#ifdef SHIFTERBUTTONS
+		add_class<ShifterAnalog,ButtonSource>(3),
+#endif
+#ifdef PCF8574BUTTONS
+		add_class<PCF8574Buttons,ButtonSource>(4),
+#endif
+#ifdef CANBUTTONS
+		add_class<CanButtons,ButtonSource>(5),
+#endif
+};
+#endif

--- a/Firmware/FFBoard/UserExtensions/Src/EncoderBissC.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/EncoderBissC.cpp
@@ -49,15 +49,17 @@ void EncoderBissC::Run(){
 		this->WaitForNotification();  // Wait until DMA is finished
 
 		if(updateFrame()){
-			pos = invertDirection ? -newPos : newPos;
+			int32_t halfres = 1<<(lenghtDataBit-1);
+			pos = newPos;
 			if(first){ // Prevent immediate multiturn update
-				lastPos = pos;
+				lastPos = posOffset;
 				first = false;
+				// If offset from current pos is more than half rotation add a multiturn count by setting previous position to the reloaded offset
 			}
 			//handle multiturn
-			if(pos-lastPos > 1<<(lenghtDataBit-1)){
+			if(pos-lastPos > halfres){
 				mtpos--;
-			}else if(lastPos-pos > 1<<(lenghtDataBit-1)){
+			}else if(lastPos-pos > halfres){
 				mtpos++;
 			}
 
@@ -81,8 +83,8 @@ void EncoderBissC::restoreFlash(){
 		this->spiSpeed = ((buf >> 5) & 0x3) +1;
 		this->invertDirection =  ((buf >> 7) & 1);
 	}
-	posOffset = Flash_ReadDefault(ADR_BISSENC_OFS, 0)<<std::max(0,(lenghtDataBit-16));
-
+	uint16_t restoredOffset = ( (uint16_t)(Flash_ReadDefault(ADR_BISSENC_OFS, 0) ));
+	posOffset = static_cast<int32_t>(restoredOffset) << std::max(0,(lenghtDataBit-16));
 }
 
 void EncoderBissC::saveFlash(){
@@ -90,7 +92,8 @@ void EncoderBissC::saveFlash(){
 	buf |= ((this->spiSpeed-1) & 0x3) << 5;
 	buf |= (this->invertDirection & 1) << 7;
 	Flash_Write(ADR_BISSENC_CONF1, buf);
-	Flash_Write(ADR_BISSENC_OFS, posOffset >> std::max(0,(lenghtDataBit-16)));
+	int32_t scaledOfs = posOffset >> std::max(0,(lenghtDataBit-16));
+	Flash_Write(ADR_BISSENC_OFS, (uint16_t)(scaledOfs) );
 }
 
 void EncoderBissC::configSPI() {
@@ -206,16 +209,27 @@ int32_t EncoderBissC::getPosAbs(){
 		if(useWaitSem && HAL_GetTick() - lastUpdateTick > waitThresh)
 			waitForUpdateSem.Take(waitThresh); // Wait a bit
 	}
-	return pos + mtpos * getCpr();
+	int32_t curpos = pos + mtpos * getCpr();
+	return invertDirection ? -curpos : curpos;
 }
 
 int32_t EncoderBissC::getPos(){
-	return getPosAbs()-posOffset;
+	if(invertDirection){
+		return getPosAbs()+posOffset;
+	}else{
+		return getPosAbs()-posOffset;
+	}
+
 }
 
 void EncoderBissC::setPos(int32_t newpos){
+	if(invertDirection){
+		newpos = -newpos;
+	}
+	int32_t diff = ( pos - newpos);
+	mtpos = newpos / getCpr(); // Multiturn should be reset
 
-	posOffset = pos - newpos;
+	posOffset = diff % getCpr(); // Always positive
 }
 
 

--- a/Firmware/FFBoard/UserExtensions/Src/EncoderSources.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/EncoderSources.cpp
@@ -1,0 +1,33 @@
+/*
+ * EncoderSources.cpp
+ *
+ *  Created on: Apr 18, 2024
+ *      Author: Yannick
+ */
+
+#include "constants.h"
+#include "EncoderLocal.h"
+#include "MtEncoderSPI.h"
+#include "EncoderBissC.h"
+#include "EncoderSSI.h"
+// 0-63 valid ids
+#ifndef ENCODERSOURCES_DEFAULT_OVERRIDE
+std::vector<class_entry<Encoder>> const Encoder::all_encoders =
+	{
+		add_class<Encoder, Encoder>(0),
+
+#ifdef LOCALENCODER
+		add_class<EncoderLocal, Encoder>(2),
+#endif
+
+#ifdef MTENCODERSPI
+		add_class<MtEncoderSPI, Encoder>(4),
+#endif
+#ifdef BISSENCODER
+		add_class<EncoderBissC, Encoder>(5),
+#endif
+#ifdef SSIENCODER
+		add_class<EncoderSSI, Encoder>(6),
+#endif
+};
+#endif

--- a/Firmware/FFBoard/UserExtensions/Src/FFBHIDMain.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/FFBHIDMain.cpp
@@ -11,65 +11,18 @@
 #include "tusb.h"
 #include "usb_hid_ffb_desc.h"
 
-#include "SPIButtons.h"
-#include "CanButtons.h"
-#include "LocalButtons.h"
-#include <ShifterAnalog.h>
-#include "PCF8574.h"
-
-#include "LocalAnalog.h"
-#include "CanAnalog.h"
-#include "ADS111X.h"
-
 #include "cmsis_os.h"
 extern osThreadId_t defaultTaskHandle;
 
 //////////////////////////////////////////////
-/*
- * Sources for class choosers here
- */
-// Register possible button sources (id 0-15)
-const std::vector<class_entry<ButtonSource>> button_sources =
-{
-#ifdef LOCALBUTTONS
-		add_class<LocalButtons,ButtonSource>(0),
-#endif
-#ifdef SPIBUTTONS
-		add_class<SPI_Buttons_1,ButtonSource>(1),
-#endif
-#ifdef SPIBUTTONS2
-		add_class<SPI_Buttons_2,ButtonSource>(2),
-#endif
-#ifdef SHIFTERBUTTONS
-		add_class<ShifterAnalog,ButtonSource>(3),
-#endif
-#ifdef PCF8574BUTTONS
-		add_class<PCF8574Buttons,ButtonSource>(4),
-#endif
-#ifdef CANBUTTONS
-		add_class<CanButtons,ButtonSource>(5),
-#endif
-};
 
-// Register possible analog sources (id 0-15)
-const std::vector<class_entry<AnalogSource>> analog_sources =
-{
-#ifdef ANALOGAXES
-		add_class<LocalAnalog,AnalogSource>(0),
-#endif
-#ifdef CANANALOG
-		add_class<CanAnalog<8>,AnalogSource>(1),
-#endif
-#ifdef ADS111XANALOG
-		add_class<ADS111X_AnalogSource,AnalogSource>(2),
-#endif
-};
 
 /**
  * setFFBEffectsCalc must be called in constructor of derived class to finish the setup
  */
 FFBHIDMain::FFBHIDMain(uint8_t axisCount) :
-		Thread("FFBMAIN", 256, 30),axisCount(axisCount),btn_chooser(button_sources),analog_chooser(analog_sources)
+		Thread("FFBMAIN", 256, 30),axisCount(axisCount),
+		btn_chooser(ButtonSource::all_buttonsources),analog_chooser(AnalogSource::all_analogsources)
 {
 
 	restoreFlash(); // Load parameters

--- a/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
@@ -839,7 +839,7 @@ bool TMC4671::findEncoderIndex(int32_t speed, uint16_t power,bool offsetPhiM,boo
 
 	//uint32_t mposStart = readReg(0x2A);
 	int32_t timeout = 1000; // 10s
-	for(int16_t flux = 0; flux <= power; flux+=10){
+	for(int16_t flux = 0; flux <= power; flux+=1+power/250){
 		setFluxTorque(flux, 0);
 		Delay(3);
 	}
@@ -987,7 +987,7 @@ void TMC4671::bangInitEnc(int16_t power){
 	setPhiE_ext(phiEpos);
 	setPhiEtype(PhiE::ext);
 	// Ramp up flux
-	for(int16_t flux = 0; flux <= power; flux+=10){
+	for(int16_t flux = 0; flux <= power; flux+=1+power/250){
 		setFluxTorque(flux, 0);
 		Delay(3);
 	}
@@ -1062,7 +1062,7 @@ void TMC4671::calibrateAenc(){
 	setMotionMode(MotionMode::torque,true);
 
 	if(this->conf.motconf.motor_type == MotorType::STEPPER || this->conf.motconf.motor_type == MotorType::BLDC){
-		for(int16_t flux = 0; flux <= bangInitPower; flux+=10){
+		for(int16_t flux = 0; flux <= bangInitPower; flux+=1+bangInitPower / 200){
 			setFluxTorque(flux, 0);
 			Delay(5);
 		}
@@ -1188,7 +1188,7 @@ bool TMC4671::checkEncoder(){
 
 	setPhiE_ext(startAngle);
 	// Ramp up flux
-	for(int16_t flux = 0; flux <= 2*bangInitPower/3; flux+=20){
+	for(int16_t flux = 0; flux <= 2*bangInitPower/3; flux+=1+bangInitPower/250){
 		setFluxTorque(flux, 0);
 		Delay(2);
 	}
@@ -2272,7 +2272,7 @@ void TMC4671::estimateABNparams(){
 	setPhiEtype(PhiE::ext);
 	setFluxTorque(0, 0);
 	setMotionMode(MotionMode::torque,true);
-	for(int16_t flux = 0; flux <= bangInitPower; flux+=10){
+	for(int16_t flux = 0; flux <= bangInitPower; flux+=1+bangInitPower/200){
 		setFluxTorque(flux, 0);
 		Delay(5);
 	}
@@ -2327,7 +2327,7 @@ void TMC4671::estimateExtEnc(){
 	setPhiEtype(PhiE::ext);
 	setFluxTorque(0, 0);
 	setMotionMode(MotionMode::torque,true);
-	for(int16_t flux = 0; flux <= bangInitPower; flux+=10){
+	for(int16_t flux = 0; flux <= bangInitPower; flux+=1+bangInitPower/200){
 		setFluxTorque(flux, 0);
 		Delay(5);
 	}

--- a/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/TMC4671.cpp
@@ -186,7 +186,7 @@ void TMC4671::restoreFlash(){
 }
 
 bool TMC4671::hasPower(){
-	uint16_t intV = getIntV();
+	int32_t intV = getIntV();
 	return (intV > 10000) && (getExtV() > 10000) && (intV < 78000);
 }
 

--- a/Firmware/FFBoard/UserExtensions/Src/mainclass_chooser.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/mainclass_chooser.cpp
@@ -30,6 +30,7 @@
 #endif
 
 // Add all classes here
+#ifndef CLASSREGISTRY_OVERRIDE
 const std::vector<class_entry<FFBoardMain>> class_registry =
 {
 		add_class<FFBoardMain,FFBoardMain>(0),
@@ -60,5 +61,6 @@ const std::vector<class_entry<FFBoardMain>> class_registry =
 
 		add_class<CustomMain,FFBoardMain>()
 };
+#endif
 
 


### PR DESCRIPTION
Changes:
- Fixed BISS-C encoder sometimes overflowing one rotation at startup
- Added BISS-C direction inversion function (Default true). Most BISS-C encoders count CW while most others and TMC count CCW.
- Standardized encoder counting direction counting up in CCW direction as a more common industrial standard
- Fixed idle spring effect not working before first save
- Retuned speed limiter function. Removed averaging. Should be more stable for high resolution encoders if high bandwidth speed filter preset is selected
- Force ramps up slowly on potential sharp position changes such as recentering
- FFB led now shows FFB state. On when FFB actuators enabled. Still blinks on clipping