### PR TITLE
Tested zero length CAN msg fix

### DIFF
--- a/Firmware/FFBoard/Src/CANPort2B.cpp
+++ b/Firmware/FFBoard/Src/CANPort2B.cpp
@@ -356,6 +356,7 @@ CommandStatus CANPort_2B::command(const ParsedCommand& cmd,std::vector<CommandRe
 			CAN_tx_msg msg;
 			memcpy(msg.data,&cmd.val,8);
 			msg.header.id = cmd.adr;
+			msg.header.length = 8;  //Sqwince:testing fix for FW ver1.16.0 zero length msg defect.
 			sendMessage(msg);
 		}else{
 			return CommandStatus::NOT_FOUND;


### PR DESCRIPTION
Added msg.header.length = 8; to fix the zero length CAN message bug I was seeing. Tested and seems to work. 