### PR TITLE
Release 1.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Changes this version:
-- Added remote CAN button/analog source mainclass
+- Added exponential torque postprocessing for game effects
 
 ### Changes in 1.16:
 
@@ -15,3 +15,4 @@ Internal changes:
 - F407: ADC now triggered by timer to reduce interrupt frequency
 - Using analog VREF for voltage sensing (better accuracy with unstable 3.3V)
 - Added chip temperature readout
+- Added remote CAN button/analog source mainclass

--- a/Firmware/FFBoard/Inc/Axis.h
+++ b/Firmware/FFBoard/Inc/Axis.h
@@ -59,6 +59,7 @@ struct AxisFlashAddrs
 	uint16_t encoderRatio = ADR_AXIS1_ENC_RATIO;
 
 	uint16_t speedAccelFilter = ADR_AXIS1_SPEEDACCEL_FILTER;
+	uint16_t postprocess1 = ADR_AXIS1_POSTPROCESS1;
 };
 
 struct AxisConfig
@@ -92,7 +93,8 @@ struct GearRatio_t{
 enum class Axis_commands : uint32_t{
 	power=0x00,degrees=0x01,esgain,zeroenc,invert,idlespring,axisdamper,enctype,drvtype,
 	pos,maxspeed,maxtorquerate,fxratio,curtorque,curpos,curspd,curaccel,reductionScaler,
-	filterSpeed, filterAccel, filterProfileId,cpr,axisfriction,axisinertia
+	filterSpeed, filterAccel, filterProfileId,cpr,axisfriction,axisinertia,
+	expo,exposcale
 };
 
 class Axis : public PersistentStorage, public CommandHandler, public ErrorHandler
@@ -159,12 +161,15 @@ public:
 	int32_t getTorque(); // current torque scaled as a 32 bit signed value
 	int16_t updateEndstop();
 
+	int32_t calculateExpoTorque(int32_t torque);
+
 	void startForceFadeIn(float start = 0,float fadeTime = 0.5);
 
 	metric_t* getMetrics();
 
 	void setEffectTorque(int32_t torque);
 	bool updateTorque(int32_t* totalTorque);
+
 
 	void setGearRatio(uint8_t numerator,uint8_t denominator);
 
@@ -271,8 +276,14 @@ private:
 	void setFxRatio(uint8_t val);
 	void updateTorqueScaler();
 
+	void setExpo(int val);
+
 
 	GearRatio_t gearRatio;
+
+	int expoValInt = 0; // expo v = val*2 => v<0 ? 1/-v : v
+	float expo = 1;
+	float expoScaler = 50; // 0.28 to 3.54
 
 };
 

--- a/Firmware/FFBoard/Inc/CAN.h
+++ b/Firmware/FFBoard/Inc/CAN.h
@@ -41,6 +41,7 @@ public:
 		const CAN_INITTYPE init;
 		const uint32_t speed;
 		const char* name;
+		constexpr PresetEntry(const CAN_INITTYPE init,const uint32_t speed,const char* name):init(init),speed(speed),name(name){}
 	};
 	constexpr CANPortHardwareConfig(const bool canChangeSpeed,std::span<const PresetEntry> presets_list)
 	: canChangeSpeed(canChangeSpeed),presets(presets_list){}

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,16,3}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,16,4}; // Version as array. 8 bit each!
 #ifndef MAX_AXIS
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #endif

--- a/Firmware/FFBoard/Src/Axis.cpp
+++ b/Firmware/FFBoard/Src/Axis.cpp
@@ -239,7 +239,7 @@ void Axis::restoreFlash(){
 
 	uint16_t pp1;
 	if(Flash_Read(flashAddrs.postprocess1, &pp1)){
-		setExpo(pp1 & 0xff);
+		setExpo((int8_t)(pp1 & 0xff));
 	}
 
 }

--- a/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/eeprom_addresses.h
@@ -13,11 +13,11 @@
 
 #include "main.h"
 // Change this to the amount of currently registered variables
-#define NB_OF_VAR 161
+#define NB_OF_VAR 164
 extern const uint16_t VirtAddVarTab[NB_OF_VAR];
 
 // Amount of variables in exportable list
-#define NB_EXPORTABLE_ADR 146
+#define NB_EXPORTABLE_ADR 149
 extern const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR];
 
 
@@ -103,6 +103,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS1_SPEEDACCEL_FILTER 0x309 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS1_ENC_RATIO 0x30A // Accel filter Lowpass
 #define ADR_AXIS1_EFFECTS2 0x30B // 0-7 Friction, 8-15 Inertia
+#define ADR_AXIS1_POSTPROCESS1 0x30C // 0-7 expo curve
 // TMC1
 #define ADR_TMC1_MOTCONF 0x320 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC1_CPR 0x321
@@ -128,6 +129,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS2_SPEEDACCEL_FILTER 0x349 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS2_ENC_RATIO 0x34A // Store the encoder ratio for an axis
 #define ADR_AXIS2_EFFECTS2 0x34B // 0-7 Friction, 8-15 Inertia
+#define ADR_AXIS2_POSTPROCESS1 0x34C // 0-7 expo curve
 // TMC2
 #define ADR_TMC2_MOTCONF 0x360 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC2_CPR 0x361
@@ -153,6 +155,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_AXIS3_SPEEDACCEL_FILTER 0x389 // Speed/Accel filter Lowpass profile
 #define ADR_AXIS3_ENC_RATIO 0x38A // Store the encoder ratio for an axis
 #define ADR_AXIS3_EFFECTS2 0x38B // 0-7 Friction, 8-15 Inertia
+#define ADR_AXIS3_POSTPROCESS1 0x38C // 0-7 expo curve
 // TMC3
 #define ADR_TMC3_MOTCONF 0x3A0 // 0-2: MotType 3-5: PhiE source 6-15: Poles
 #define ADR_TMC3_CPR 0x3A1
@@ -216,6 +219,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data) will return 1 if 
 #define ADR_LOCALANALOG_MAX_6 0x50D
 #define ADR_LOCALANALOG_MIN_7 0x50E
 #define ADR_LOCALANALOG_MAX_7 0x50F
+// ADS111X
 #define ADR_ADS111X_MIN_0 0x510
 #define ADR_ADS111X_MAX_0 0x511
 #define ADR_ADS111X_MIN_1 0x512

--- a/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
+++ b/Firmware/FFBoard/UserExtensions/Src/eeprom_addresses.c
@@ -29,6 +29,9 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_FFBWHEEL_BUTTONCONF,
 	ADR_FFBWHEEL_ANALOGCONF,
 	ADR_FFBWHEEL_CONF1,
+// CAN remote
+	ADR_CANREMOTE_CONF1,
+	ADR_CANREMOTE_CONF2,
 // Button Sources:
 	ADR_SPI_BTN_1_CONF,
 	ADR_SHIFTERANALOG_CONF,
@@ -82,6 +85,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS1_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS1_ENC_RATIO, // Accel filter Lowpass
 	ADR_AXIS1_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS1_POSTPROCESS1, // 0-7 expo curve
 // TMC1
 	ADR_TMC1_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC1_CPR,
@@ -107,6 +111,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS2_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS2_ENC_RATIO, // Store the encoder ratio for an axis
 	ADR_AXIS2_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS2_POSTPROCESS1, // 0-7 expo curve
 // TMC2
 	ADR_TMC2_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC2_CPR,
@@ -132,6 +137,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_AXIS3_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS3_ENC_RATIO, // Store the encoder ratio for an axis
 	ADR_AXIS3_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS3_POSTPROCESS1, // 0-7 expo curve
 // TMC3
 	ADR_TMC3_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC3_CPR,
@@ -195,6 +201,7 @@ const uint16_t VirtAddVarTab[NB_OF_VAR] =
 	ADR_LOCALANALOG_MAX_6,
 	ADR_LOCALANALOG_MIN_7,
 	ADR_LOCALANALOG_MAX_7,
+// ADS111X
 	ADR_ADS111X_MIN_0,
 	ADR_ADS111X_MAX_0,
 	ADR_ADS111X_MIN_1,
@@ -222,6 +229,9 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_FFBWHEEL_BUTTONCONF,
 	ADR_FFBWHEEL_ANALOGCONF,
 	ADR_FFBWHEEL_CONF1,
+// CAN remote
+	ADR_CANREMOTE_CONF1,
+	ADR_CANREMOTE_CONF2,
 // Button Sources:
 	ADR_SPI_BTN_1_CONF,
 	ADR_SHIFTERANALOG_CONF,
@@ -275,6 +285,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS1_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS1_ENC_RATIO, // Accel filter Lowpass
 	ADR_AXIS1_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS1_POSTPROCESS1, // 0-7 expo curve
 // TMC1
 	ADR_TMC1_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC1_CPR,
@@ -300,6 +311,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS2_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS2_ENC_RATIO, // Store the encoder ratio for an axis
 	ADR_AXIS2_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS2_POSTPROCESS1, // 0-7 expo curve
 // TMC2
 	ADR_TMC2_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC2_CPR,
@@ -325,6 +337,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_AXIS3_SPEEDACCEL_FILTER, // Speed/Accel filter Lowpass profile
 	ADR_AXIS3_ENC_RATIO, // Store the encoder ratio for an axis
 	ADR_AXIS3_EFFECTS2, // 0-7 Friction, 8-15 Inertia
+	ADR_AXIS3_POSTPROCESS1, // 0-7 expo curve
 // TMC3
 	ADR_TMC3_MOTCONF, // 0-2: MotType 3-5: PhiE source 6-15: Poles
 	ADR_TMC3_CPR,
@@ -388,6 +401,7 @@ const uint16_t exportableFlashAddresses[NB_EXPORTABLE_ADR] =
 	ADR_LOCALANALOG_MAX_6,
 	ADR_LOCALANALOG_MIN_7,
 	ADR_LOCALANALOG_MAX_7,
+// ADS111X
 	ADR_ADS111X_MIN_0,
 	ADR_ADS111X_MAX_0,
 	ADR_ADS111X_MIN_1,

--- a/Firmware/scripts/memory_map.csv
+++ b/Firmware/scripts/memory_map.csv
@@ -67,6 +67,7 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS1_SPEEDACCEL_FILTER,0x309,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS1_ENC_RATIO,0x30A,// Accel filter Lowpass,1,1
 ,ADR_AXIS1_EFFECTS2,0x30B,"// 0-7 Friction, 8-15 Inertia",1,1
+,ADR_AXIS1_POSTPROCESS1,0x30C,// 0-7 expo curve,1,1
 // TMC1,,,,,
 ,ADR_TMC1_MOTCONF,0x320,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC1_CPR,0x321,,1,1
@@ -92,6 +93,13 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS2_SPEEDACCEL_FILTER,0x349,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS2_ENC_RATIO,0x34A,// Store the encoder ratio for an axis,1,1
 ,ADR_AXIS2_EFFECTS2,0x34B,"// 0-7 Friction, 8-15 Inertia",1,1
+,ADR_AXIS2_POSTPROCESS1,0x34C,// 0-7 expo curve,1,1
+,,,,,
+,,,,,
+,,,,,
+,,,,,
+,,,,,
+,,,,,
 // TMC2,,,,,
 ,ADR_TMC2_MOTCONF,0x360,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC2_CPR,0x361,,1,1
@@ -117,6 +125,9 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_AXIS3_SPEEDACCEL_FILTER,0x389,// Speed/Accel filter Lowpass profile,1,1
 ,ADR_AXIS3_ENC_RATIO,0x38A,// Store the encoder ratio for an axis,1,1
 ,ADR_AXIS3_EFFECTS2,0x38B,"// 0-7 Friction, 8-15 Inertia",1,1
+,ADR_AXIS3_POSTPROCESS1,0x38C,// 0-7 expo curve,1,1
+,,,,,
+,,,,,
 // TMC3,,,,,
 ,ADR_TMC3_MOTCONF,0x3A0,// 0-2: MotType 3-5: PhiE source 6-15: Poles,1,1
 ,ADR_TMC3_CPR,0x3A1,,1,1
@@ -183,6 +194,7 @@ Section comment,Name,Value,Comment on key,VirtAddVarTab,exportableFlashAddresses
 ,ADR_LOCALANALOG_MAX_6,0x50D,,1,1
 ,ADR_LOCALANALOG_MIN_7,0x50E,,1,1
 ,ADR_LOCALANALOG_MAX_7,0x50F,,1,1
+// ADS111X,,,,,
 ,ADR_ADS111X_MIN_0,0x510,,1,1
 ,ADR_ADS111X_MAX_0,0x511,,1,1
 ,ADR_ADS111X_MIN_1,0x512,,1,1


### PR DESCRIPTION
Adds exponential curve torque postprocessing (Experimental)
This can be useful for openloop PWM DC motors or to compensate for low details or overamplified forces in some situations.
Most DD wheel users should not use it.

Fixes compatibility with new GCC versions by adding an explicit constructor for the CAN Preset entries.