### PR TITLE
Adding MagnTek MT6835 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Changes this version:
-- Added exponential torque postprocessing for game effects
+- Reformatted USB serial string as hex and added command to request UID as hex string
+- Added device name to USB Product name
+- Added support for F407 OTP section
 
 ### Changes in 1.16:
 
@@ -16,3 +18,4 @@ Internal changes:
 - Using analog VREF for voltage sensing (better accuracy with unstable 3.3V)
 - Added chip temperature readout
 - Added remote CAN button/analog source mainclass
+- Added exponential torque postprocessing for game effects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Reformatted USB serial string as hex and added command to request UID as hex string
 - Added device name to USB Product name
 - Added support for F407 OTP section
+- Added support for MagnTek MT6835 via SPI (SPI3 port, MagnTek encoder class)
 
 ### Changes in 1.16:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# How to contribute
+
+## General terms
+
+1. By contributing to this project you grant the repository owner the full copyright to the contribution.
+2. Generally small changes and fixes are more likely to be merged as large changes can easily lead to conflicts in the future.
+3. A change in the common codebase must not cause additional issues in target subprojects. It must compile for all subprojects.
+4. Changes to pins, interrupts, task priorities, heap/stack sizes must be carefully examined for side effects as they can have unintended consequences in seemingly unrelated modules. Generally do not change these unless absolutely required and tested.
+5. Read the [wiki](https://github.com/Ultrawipf/OpenFFBoard/wiki) for additional information about [pinouts](https://github.com/Ultrawipf/OpenFFBoard/wiki/Pinouts-and-peripherals), features, [commands](https://github.com/Ultrawipf/OpenFFBoard/wiki/Commands) and contribution info
+
+### Simplified steps for contribution
+1. Clone/Fork the projects master branch
+2. Make your changes and create a commit (If it requires GUI features to be changed it is recommended to do the same with the [configurator repo](https://github.com/Ultrawipf/OpenFFBoard-configurator) or if its just a small change detail what the effect is and request a change)
+3. Create a pull request for your fork against master and describe your contribution in a detailed way. What bug does it fix? Which feature is added?
+4. Wait for approval and append requested changes to your branch
+5. Your code gets squash/rebase merged if approved
+
+### Release workflow
+Changes should be added in the CHANGELOG.md file.
+This will be used to generate release notes.
+A tagged commit (v1.x.x) will trigger an automatic release. A tag with a "-" (v1.x.x-beta) generates a prerelease.
+
+A release is triggered when changes are deemed ready for public use.
+
+### Submodules
+The configurator is an important part of the project and should be kept up to date with any changes required to support a firmware and the submodule should if possible point to a commit that works with the corresponding firmware version.
+
+Pull the submodules with `git submodule update --init`.
+
+### Branches
+If you directly push a branch to the project as a developer your branch name should contain your username or the type of feature. Like `ultrawipf/warpspeed` or `feature/pwmdriver`.
+Set your git author name correctly before committing.
+
+### Code style
+The code should follow the same style as the other parts of the project and you should use easy to understand comments for complex statements and new functions.
+
+### Flash storage
+If you require a variable to be stored in flash check the eeprom emulation functions and choose an address according to `scripts/memory_map.csv` and add it to the list in [`scripts/memory_map.csv`](../../Firmware/scripts/memory_map.csv). 
+
+The script `scripts/generate_memory.py` is used to generate `eeprom_addresses.c` and `eeprom_addresses.h` from the csv file to keep track of used addresses and automatically set the right defitions.
+
+In general you should use a block of addresses per class and use the space efficiently. If you have 5 bools and an 8 bit int to store don't use 6 full addresses but pack them into a single uint16_t.

--- a/Firmware/FFBoard/Inc/SystemCommands.h
+++ b/Firmware/FFBoard/Inc/SystemCommands.h
@@ -11,7 +11,7 @@
 #include "CommandHandler.h"
 
 enum class FFBoardMain_commands : uint32_t{
-	help=0,save=1,reboot=2,dfu=3,swver=4,hwtype=5,lsmain,main,lsactive,format,errors,errorsclr,flashdump,flashraw,vint,vext,mallinfo,heapfree,taskstats,debug,devid,uid,temp
+	help=0,save=1,reboot=2,dfu=3,swver=4,hwtype=5,lsmain,main,lsactive,format,errors,errorsclr,flashdump,flashraw,vint,vext,mallinfo,heapfree,taskstats,debug,devid,uid,temp,otp,signature
 };
 
 class SystemCommands : public CommandHandler {

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,16,4}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,16,5}; // Version as array. 8 bit each!
 #ifndef MAX_AXIS
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #endif
@@ -97,6 +97,15 @@ static const uint8_t SW_VERSION_INT[3] = {1,16,4}; // Version as array. 8 bit ea
 
 #if defined(TIM_MICROS_HALTICK) && defined(TIM_MICROS)
 #error "Only TIM_MICROS_HALTICK OR TIM_MICROS may be defined as a microsecond timebase"
+#endif
+
+#ifndef SIGNATURELEN
+#define SIGNATURELEN 8
+#define SIGNATURE
+#endif
+
+#if defined(FLASH_OTP_BASE) && defined(FLASH_OTP_END)
+#define OTPMEMORY
 #endif
 
 

--- a/Firmware/FFBoard/Inc/flash_helpers.h
+++ b/Firmware/FFBoard/Inc/flash_helpers.h
@@ -31,6 +31,9 @@ bool Flash_ReadWriteDefault(uint16_t adr,uint16_t *buf,uint16_t def); // returns
 void Flash_Dump(std::vector<std::tuple<uint16_t,uint16_t>> *result,bool includeAll = false);
 bool Flash_Format();
 
+bool OTP_Write(uint16_t adroffset,uint64_t dat);
+bool OTP_Read(uint16_t adroffset,uint64_t* dat);
+
 
 template<typename TVal>
 inline TVal Flash_ReadDefault(uint16_t adr, TVal def) {

--- a/Firmware/FFBoard/Src/SystemCommands.cpp
+++ b/Firmware/FFBoard/Src/SystemCommands.cpp
@@ -69,7 +69,7 @@ void SystemCommands::registerCommands(){
 	CommandHandler::registerCommand("devid", FFBoardMain_commands::devid, "Get chip dev id and rev id",CMDFLAG_GET);
 	CommandHandler::registerCommand("name", CommandHandlerCommands::name, "name of class",CMDFLAG_GET|CMDFLAG_STR_ONLY);
 	CommandHandler::registerCommand("cmdinfo", CommandHandlerCommands::cmdinfo, "Flags of a command id (adr). -1 if cmd id invalid",CMDFLAG_GETADR);
-	CommandHandler::registerCommand("uid", FFBoardMain_commands::uid, "Get 96b chip uid. Adr0-2 sel blk",CMDFLAG_GET | CMDFLAG_GETADR);
+	CommandHandler::registerCommand("uid", FFBoardMain_commands::uid, "Get 96b chip uid. Adr0-2 sel blk",CMDFLAG_GET | CMDFLAG_GETADR | CMDFLAG_INFOSTRING);
 	CommandHandler::registerCommand("temp", FFBoardMain_commands::temp, "Chip temperature in C",CMDFLAG_GET);
 }
 
@@ -279,6 +279,10 @@ CommandStatus SystemCommands::internalCommand(const ParsedCommand& cmd,std::vect
 				}else if(cmd.adr == 2){
 					replies.emplace_back(HAL_GetUIDw2());
 				}
+			}else if(cmd.type == CMDtype::info){
+				char buf[32];
+				std::snprintf(buf,32,"0x%08lx%08lx%08lx",HAL_GetUIDw2(),HAL_GetUIDw1(),HAL_GetUIDw0()); // Print as hex string
+				replies.emplace_back(std::string(buf));
 			}
 			break;
 		case FFBoardMain_commands::temp:

--- a/Firmware/FFBoard/Src/USBdevice.cpp
+++ b/Firmware/FFBoard/Src/USBdevice.cpp
@@ -11,7 +11,7 @@
 uint16_t _desc_str[USB_STRING_DESC_BUF_SIZE]; // String buffer
 
 USBdevice::USBdevice(const tusb_desc_device_t* deviceDesc,const uint8_t (*confDesc),const usb_string_desc_t* strings, uint8_t appendSerial) :
-Thread("USB", 256, 40), desc_device(deviceDesc), desc_conf(confDesc), string_desc(strings),appendSerial(appendSerial) {
+Thread("USB", 330, 40), desc_device(deviceDesc), desc_conf(confDesc), string_desc(strings),appendSerial(appendSerial) {
 
 }
 

--- a/Firmware/FFBoard/Src/USBdevice.cpp
+++ b/Firmware/FFBoard/Src/USBdevice.cpp
@@ -41,7 +41,9 @@ void USBdevice::Run(){
  *  Generates a unique id string from the hardware id
  */
 std::string USBdevice::getUsbSerial(){
-	std::string serial = std::to_string(HAL_GetUIDw0()) + std::to_string(HAL_GetUIDw1()) + std::to_string(HAL_GetUIDw2());
+	char buf[25];
+	std::snprintf(buf,25,"%08lx%08lx%08lx",HAL_GetUIDw2(),HAL_GetUIDw1(),HAL_GetUIDw0()); // Print as hex string
+	std::string serial{buf}; //std::to_string(HAL_GetUIDw0()) + std::to_string(HAL_GetUIDw1()) + std::to_string(HAL_GetUIDw2());
 
 	return serial;
 }
@@ -76,7 +78,7 @@ uint16_t* USBdevice::getUsbStringDesc(uint8_t index,uint16_t langid){
 			field = string_desc->interfaces[index-4];
 			if(appendSerial){
 				field += "(";
-				field.append(getUsbSerial().substr(0, appendSerial));
+				field.append(std::to_string(HAL_GetUIDw0()).substr(0, appendSerial));
 				field += ")";
 			}
 		}else{

--- a/Firmware/FFBoard/UserExtensions/Src/mainclass_chooser.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/mainclass_chooser.cpp
@@ -66,7 +66,9 @@ const std::vector<class_entry<FFBoardMain>> class_registry =
 		add_class<CANInputMain,FFBoardMain>(),
 #endif
 
-		add_class<CustomMain,FFBoardMain>()
+#ifdef CUSTOMMAINNAME
+		add_class<CUSTOMMAINNAME,FFBoardMain>()
+#endif
 };
 #endif
 

--- a/Firmware/FFBoard/UserExtensions/Src/usb_descriptors.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/usb_descriptors.cpp
@@ -23,7 +23,7 @@ const tusb_desc_device_t usb_devdesc_ffboard_composite =
     .bcdUSB             = 0x0200,
 
     // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
-    .bDeviceClass       = TUSB_CLASS_MISC,
+    .bDeviceClass       = TUSB_CLASS_UNSPECIFIED,
     .bDeviceSubClass    = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol    = MISC_PROTOCOL_IAD,
     .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
@@ -118,7 +118,7 @@ uint8_t const usb_cdc_midi_conf[] =
 const usb_string_desc_t usb_ffboard_strings_default = {
 	.langId = 0x0409,
 	.manufacturer = "Open FFBoard",
-	.product = "FFBoard",
+	.product = "FFBoard " HW_TYPE,
 	// Interfaces start at index 4
 	.interfaces = {"FFBoard CDC", "FFBoard HID","FFBoard MIDI"}
 };

--- a/Firmware/Targets/F407VG/Core/Inc/target_constants.h
+++ b/Firmware/Targets/F407VG/Core/Inc/target_constants.h
@@ -138,4 +138,6 @@ extern CAN_HandleTypeDef hcan1;
 
 #define CCRAM_SEC ".ccmram"
 
+#define SIGBNATUREBASEADR 0 // First block in OTP
+
 #endif /* INC_TARGET_CONSTANTS_H_ */

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The GUI for configuration is found at [OpenFFBoard-configurator](https://github.
 These git submodules can be pulled with `git submodule init` and `git submodule update`
 
 Updates often require matching firmware and GUI versions!
+For binary releases check the [github release section](https://github.com/Ultrawipf/OpenFFBoard/releases).
 
 ## Documentation
 Documentation will be updated in the [GitHub Wiki](https://github.com/Ultrawipf/OpenFFBoard/wiki).
@@ -43,6 +44,43 @@ Available commands are listed on the [Commands wiki page](https://github.com/Ult
 Code summary and documentation of the latest stable version is available as a [Doxygen site](https://ultrawipf.github.io/OpenFFBoard/doxygen/).
 
 For discussion and progress updates we have a [Discord server](https://discord.com/invite/gHtnEcP).
+
+
+## Features
+For more information, [game compatibility](https://github.com/Ultrawipf/OpenFFBoard/wiki/Games-setup#compatibility-list) and common setups check the [GitHub Wiki](https://github.com/Ultrawipf/OpenFFBoard/wiki).
+### Main modes:
+See [other mainclasses](https://github.com/Ultrawipf/OpenFFBoard/wiki/Commands#other-mainclasses) for full list.
+* **FFB Wheel**: 	USB 1 Axis force feedback device with HID FFB support, multiple analog axis inputs (see analog sources) and digital buttons (see digital sources)
+* **FFB Joystick**: USB 2 Axis force feedback device
+
+* **EXT FFB Gamepad**: USB 2 axis gamepad device without HID FFB. Use this for simple non FFB devices or send custom FFB data via commands (See [Ext FFB mode](https://github.com/Ultrawipf/OpenFFBoard/wiki/External-FFB-mode))
+* **CAN Remote Analog/Digital**: Send all supported digital and analog inputs as CAN packets to a main FFBoard (Receive using CAN Analog/Digital source)
+---
+* **CAN Interface**: GVRET compatible CAN interface for CAN bus debugging
+
+### Supported motor drivers
+|Name|Interface|1ch Wheel support|2ch Joystick support|Supported motors|Supported encoders|Enc forwarding (see [FFBoard supported encoders](#supported-encoders))|Dual interface encoder
+|--|--|--|--|--|--|--|--|
+**OpenFFBoard TMC4671**|SPI|yes✅|limited⚠️|3 phase servo (BLDC), 2ph stepper (w. encoder), (DC) | ABZ, SinCos, (Digital Hall), Analog hall | yes✅|yes✅
+ODrive|CAN|yes✅|yes✅|3 phase servo | ABZ, SPI, Internal (See ODrive docs) | no❌|no❌
+VESC|CAN|yes✅|yes✅|3 phase servo| ABZ | no❌|yes✅
+PWM|PWM pins|yes✅|no❌|Any external driver (PWM+Dir, Centered, RC PPM, 2x PWM)| Any [FFBoard encoder](#supported-encoders) | no❌|no❌
+MyActuator|CAN|yes✅|yes✅|Integrated in servo| Internal | no❌|no❌
+Simplemotion|RS432 w. adapter⚠️|yes✅|no❌|3 phase servo, Stepper| ABZ, BISS-C | no❌|no❌
+
+
+### Supported encoders
+Encoders supported directly by FFBoard firmware and main board
+
+Can be forwarded to TMC4671 using external encoder forwarding
+
+|Name|Interface|Absolute|
+|-|-|-|
+|ABZ Quadrature|ABZ|no❌|
+|BISS-C|SPI w. Adapter⚠️|yes✅|
+|MagnTek (MT6825,MT6835)|SPI + ABZ|yes✅|
+|SSI|SPI|yes✅|
+
 
 ### Extensions
 The modular structure means you are free to implement your own main classes.


### PR DESCRIPTION
Version 1.16.5

Changes:

- Reformatted USB serial string as hex and added command to request UID as hex string (Will cause windows to detect a new device)
- Added device name to USB Product name
- Added support for F407 OTP section
- Added support for MagnTek MT6835 via SPI (SPI3 port, MagnTek encoder class)
