### PR TITLE
Make SPI_Buttons command spispeed more verbose

### DIFF
--- a/Firmware/FFBoard/UserExtensions/Inc/SPIButtons.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/SPIButtons.h
@@ -55,6 +55,7 @@ public:
 
 	const uint8_t maxButtons = 64;
 	std::string printModes(const std::vector<std::string>& names);
+	std::string printSpeeds(const std::vector<std::string>& names);
 
 	void setMode(SPI_BtnMode mode);
 	void initSPI();

--- a/Firmware/FFBoard/UserExtensions/Src/SPIButtons.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/SPIButtons.cpp
@@ -193,8 +193,18 @@ uint8_t SPI_Buttons::readButtons(uint64_t* buf){
 
 std::string SPI_Buttons::printModes(const std::vector<std::string>& names){
 	std::string reply;
-	for(uint8_t i = 0; i<names.size();i++){
-		reply+=  names[i]  + ":" + std::to_string(i)+"\n";
+	for(uint8_t i = 0; i < names.size(); ++i){
+		reply += names[i] + ": " + std::to_string(i) + "\n";
+	}
+	return reply;
+}
+
+std::string SPI_Buttons::printSpeeds(const std::vector<std::string>& names){
+	std::string reply;
+	for(uint8_t i = 0; i < names.size(); ++i){
+	  reply += names[i] + ": " +
+	    std::to_string(this->speedPresets[i]) + " (" +
+	    std::to_string(spiPort.getBaseClk() / (double)this->speedPresets[i]) + " Hz)\n";
 	}
 	return reply;
 }
@@ -253,7 +263,7 @@ CommandStatus SPI_Buttons::command(const ParsedCommand& cmd,std::vector<CommandR
 		}else if(cmd.type == CMDtype::get){
 			replies.emplace_back((uint8_t)this->conf.spi_speed);
 		}else if(cmd.type == CMDtype::info){
-			replies.emplace_back(printModes(this->speed_names));
+			replies.emplace_back(printSpeeds(this->speed_names));
 		}else{
 			return CommandStatus::ERR;
 		}


### PR DESCRIPTION
Trying to get an RP2040 to act as a slave over SPI, I went down a rabbit hole of debugging.
Having an easier way to printout the SPI speeds would have helped me quite a bit.

I understand that my use case is quite niche and can totally see why this wouldn't be deemed suitable for upstream.