### PR TITLE
Fix SPI_Buttons constructor procedure

### DIFF
--- a/Firmware/FFBoard/Inc/CAN.h
+++ b/Firmware/FFBoard/Inc/CAN.h
@@ -11,6 +11,7 @@
 #ifdef CANBUS
 //#include "CanHandler.h"
 #include "main.h"
+#include <algorithm>
 #include <vector>
 #include "semaphore.hpp"
 #include <GPIOPin.h>

--- a/Firmware/FFBoard/Inc/ringbufferwrapper.h
+++ b/Firmware/FFBoard/Inc/ringbufferwrapper.h
@@ -57,7 +57,7 @@ T RingBufferWrapper::peek_as(bool* ok) noexcept
    T data;
    // Only POD types can be trivially copied from
    // the ring buffer.
-   if (!std::is_pod<T>::value) {
+   if (!std::is_standard_layout<T>::value && !std::is_trivial<T>::value) {
       *ok = false;
       return data;
    }

--- a/Firmware/FFBoard/Src/CommandHandler.cpp
+++ b/Firmware/FFBoard/Src/CommandHandler.cpp
@@ -12,6 +12,7 @@
 #include "CDCcomm.h"
 //#include <set>
 #include "ChoosableClass.h"
+#include <algorithm>
 
 //std::vector<CommandHandler*> CommandHandler::cmdHandlers;
 //std::set<uint16_t> CommandHandler::cmdHandlerIDs;

--- a/Firmware/FFBoard/Src/ErrorHandler.cpp
+++ b/Firmware/FFBoard/Src/ErrorHandler.cpp
@@ -10,6 +10,7 @@
 #include "FFBoardMain.h"
 #include "cppmain.h"
 #include "critical.hpp"
+#include <algorithm>
 #include <span>
 
 std::vector<ErrorHandler*> ErrorHandler::errorHandlers;

--- a/Firmware/FFBoard/UserExtensions/Src/SPIButtons.cpp
+++ b/Firmware/FFBoard/UserExtensions/Src/SPIButtons.cpp
@@ -51,13 +51,6 @@ SPI_Buttons::SPI_Buttons(uint16_t configuration_address, uint16_t configuration_
 	this->configuration_address_2 = configuration_address_2;
 	restoreFlash();
 
-	this->spiConfig.peripheral.BaudRatePrescaler = speedPresets[this->conf.spi_speed];
-	this->spiConfig.peripheral.FirstBit = SPI_FIRSTBIT_LSB;
-	this->spiConfig.peripheral.CLKPhase = SPI_PHASE_1EDGE;
-	this->spiConfig.peripheral.CLKPolarity = SPI_POLARITY_LOW;
-
-	initSPI();
-
 	registerCommands();
 	this->setCommandsEnabled(true);
 	ready  = true;
@@ -109,18 +102,17 @@ void SPI_Buttons::setConfig(ButtonSourceConfig config){
 	if(conf.mode == SPI_BtnMode::TM){
 		this->spiConfig.cspol = true;
 		this->conf.cutRight = true;
-		this->spiConfig.peripheral.CLKPolarity = SPI_POLARITY_LOW;
+		this->spiConfig.peripheral.FirstBit = SPI_FIRSTBIT_LSB;
 		this->spiConfig.peripheral.CLKPhase = SPI_PHASE_1EDGE;
-
+		this->spiConfig.peripheral.CLKPolarity = SPI_POLARITY_LOW;
 	}else if(conf.mode == SPI_BtnMode::PISOSR){
 		this->spiConfig.cspol = false;
 		this->conf.cutRight = false;
+		this->spiConfig.peripheral.FirstBit = SPI_FIRSTBIT_LSB;
 		this->spiConfig.peripheral.CLKPhase = SPI_PHASE_2EDGE;
 		this->spiConfig.peripheral.CLKPolarity = SPI_POLARITY_HIGH; // its actually shifting on the rising edge but 165 will have the first output set even before clocking. First clock cycle is actually second bit so we sample at the falling edge and skip the first bit with that.
 	}
-//	spiPort.takeSemaphore();
-//	spiPort.configurePort(&this->spiConfig.peripheral);
-//	spiPort.giveSemaphore();
+	this->spiConfig.peripheral.BaudRatePrescaler = speedPresets[this->conf.spi_speed];
 	initSPI();
 	if(config.numButtons == 64){ // Special case
 			mask = 0xffffffffffffffff;

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -26,7 +26,7 @@ BUILD_DIR = build
 ######################################
 
 # Choose your board mcu F407VG or F411RE
-MCU_TARGET=F407VG
+MCU_TARGET ?= F407VG
 # The directory of mcu target
 TARGET_DIR = Targets/$(MCU_TARGET)
 
@@ -36,7 +36,7 @@ TARGET_DIR = Targets/$(MCU_TARGET)
 TARGET = OpenFFBoard_$(MCU_TARGET)
 
 # Output directory for hex/bin files
-OUTPUT_DIR = $(BUILD_DIR)
+OUTPUT_DIR ?= $(BUILD_DIR)
 
 # C sources
 C_SOURCES = $(wildcard $(TARGET_DIR)/Core/Src/*.c)
@@ -229,15 +229,15 @@ $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 
 $(OUTPUT_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(OUTPUT_DIR)
 	$(HEX) $< $@
-	
+
 $(OUTPUT_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(OUTPUT_DIR)
-	$(BIN) $< $@	
-	
+	$(BIN) $< $@
+
 $(BUILD_DIR):
-	-mkdir $@	
-	
+	-mkdir -p $@
+
 $(OUTPUT_DIR): $(BUILD_DIR)
-	-mkdir $@
+	-mkdir -p $@
 
 #######################################
 # clean up


### PR DESCRIPTION
Currently the SPI_Buttons constructor overwrites whatever happens in `setConfig()` (as called from `restoreFlash()`) with hardcoded values which, from the looks of it, should break the PISOSR compatibility.