### PR TITLE
Velocity calculation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ### Changes this version:
-- Reformatted USB serial string as hex and added command to request UID as hex string
-- Added device name to USB Product name
-- Added support for F407 OTP section
-- Added support for MagnTek MT6835 via SPI (SPI3 port, MagnTek encoder class)
+- Added SPI speed selector to MagnTek encoders
 
 ### Changes in 1.16:
 
@@ -20,3 +17,7 @@ Internal changes:
 - Added chip temperature readout
 - Added remote CAN button/analog source mainclass
 - Added exponential torque postprocessing for game effects
+- Reformatted USB serial string as hex and added command to request UID as hex string
+- Added device name to USB Product name
+- Added support for F407 OTP section
+- Added support for MagnTek MT6835 via SPI (SPI3 port, MagnTek encoder class)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changes this version:
 - Added SPI speed selector to MagnTek encoders
+- Added "reg" and "save" commands to MagnTek encoder. Allows programming MT6835 encoders (debug=1 mode required!)
 
 ### Changes in 1.16:
 

--- a/Firmware/FFBoard/Inc/Axis.h
+++ b/Firmware/FFBoard/Inc/Axis.h
@@ -239,6 +239,7 @@ private:
 	int32_t effectTorque = 0;
 	int32_t axisEffectTorque = 0;
 	uint8_t fx_ratio_i = 204; // Reduce effects to a certain ratio of the total power to have a margin for the endstop. 80% = 204
+	uint16_t timeSincePosChange = 1;
 	uint16_t power = 5000;
 	float torqueScaler = 0; // power * fx_ratio as a ratio between 0 & 1
 	float effect_margin_scaler = 0;

--- a/Firmware/FFBoard/Inc/CAN.h
+++ b/Firmware/FFBoard/Inc/CAN.h
@@ -11,6 +11,7 @@
 #ifdef CANBUS
 //#include "CanHandler.h"
 #include "main.h"
+#include <algorithm>
 #include <vector>
 #include "semaphore.hpp"
 #include <GPIOPin.h>

--- a/Firmware/FFBoard/Inc/constants.h
+++ b/Firmware/FFBoard/Inc/constants.h
@@ -8,7 +8,7 @@
  * For more settings see target_constants.h in a target specific folder
  */
 
-static const uint8_t SW_VERSION_INT[3] = {1,16,5}; // Version as array. 8 bit each!
+static const uint8_t SW_VERSION_INT[3] = {1,16,6}; // Version as array. 8 bit each!
 #ifndef MAX_AXIS
 #define MAX_AXIS 2 // ONLY USE 2 for now else screws HID Reports
 #endif

--- a/Firmware/FFBoard/Inc/ringbufferwrapper.h
+++ b/Firmware/FFBoard/Inc/ringbufferwrapper.h
@@ -57,7 +57,7 @@ T RingBufferWrapper::peek_as(bool* ok) noexcept
    T data;
    // Only POD types can be trivially copied from
    // the ring buffer.
-   if (!std::is_pod<T>::value) {
+   if (!std::is_standard_layout<T>::value && !std::is_trivial<T>::value) {
       *ok = false;
       return data;
    }

--- a/Firmware/FFBoard/Src/CommandHandler.cpp
+++ b/Firmware/FFBoard/Src/CommandHandler.cpp
@@ -12,6 +12,7 @@
 #include "CDCcomm.h"
 //#include <set>
 #include "ChoosableClass.h"
+#include <algorithm>
 
 //std::vector<CommandHandler*> CommandHandler::cmdHandlers;
 //std::set<uint16_t> CommandHandler::cmdHandlerIDs;

--- a/Firmware/FFBoard/Src/ErrorHandler.cpp
+++ b/Firmware/FFBoard/Src/ErrorHandler.cpp
@@ -10,6 +10,7 @@
 #include "FFBoardMain.h"
 #include "cppmain.h"
 #include "critical.hpp"
+#include <algorithm>
 #include <span>
 
 std::vector<ErrorHandler*> ErrorHandler::errorHandlers;

--- a/Firmware/FFBoard/UserExtensions/Inc/MtEncoderSPI.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/MtEncoderSPI.h
@@ -19,11 +19,12 @@
 
 class MtEncoderSPI: public Encoder, public SPIDevice, public PersistentStorage, public CommandHandler,cpp_freertos::Thread{
 	enum class MtEncoderSPI_commands : uint32_t{
-		cspin,pos,errors,mode
+		cspin,pos,errors,mode,speed
 	};
 	enum class MtEncoderSPI_mode : uint8_t{
 		mt6825,mt6835
 	};
+	const std::array<float,3> spispeeds = {10e6,5e6,2.5e6}; // Target speeds. Must double each entry
 public:
 	MtEncoderSPI();
 	virtual ~MtEncoderSPI();
@@ -57,6 +58,8 @@ public:
 
 	//bool useDMA = false; // if true uses DMA for angle updates instead of polling SPI. TODO when used with tmc external encoder using DMA will hang the interrupt randomly
 
+	void setSpiSpeed(uint8_t preset);
+
 private:
 	uint8_t readSpi(uint16_t addr);
 	void writeSpi(uint16_t addr,uint8_t data);
@@ -85,6 +88,8 @@ private:
 
 	static std::array<uint8_t,256> tableCRC;
 	const uint8_t POLY = 0x07;
+
+	uint8_t spiSpeedPreset = 0;
 };
 
 #endif /* USEREXTENSIONS_SRC_MTENCODERSPI_H_ */

--- a/Firmware/FFBoard/UserExtensions/Inc/MtEncoderSPI.h
+++ b/Firmware/FFBoard/UserExtensions/Inc/MtEncoderSPI.h
@@ -19,7 +19,7 @@
 
 class MtEncoderSPI: public Encoder, public SPIDevice, public PersistentStorage, public CommandHandler,cpp_freertos::Thread{
 	enum class MtEncoderSPI_commands : uint32_t{
-		cspin,pos,errors,mode,speed
+		cspin,pos,errors,mode,speed,reg,save
 	};
 	enum class MtEncoderSPI_mode : uint8_t{
 		mt6825,mt6835
@@ -64,6 +64,7 @@ private:
 	uint8_t readSpi(uint16_t addr);
 	void writeSpi(uint16_t addr,uint8_t data);
 	void spiTxRxCompleted(SPIPort* port);
+	bool saveEeprom();
 
 
 	bool nomag = false; // Magnet lost in last report

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -26,7 +26,7 @@ BUILD_DIR = build
 ######################################
 
 # Choose your board mcu F407VG or F411RE
-MCU_TARGET=F407VG
+MCU_TARGET ?= F407VG
 # The directory of mcu target
 TARGET_DIR = Targets/$(MCU_TARGET)
 
@@ -36,7 +36,7 @@ TARGET_DIR = Targets/$(MCU_TARGET)
 TARGET = OpenFFBoard_$(MCU_TARGET)
 
 # Output directory for hex/bin files
-OUTPUT_DIR = $(BUILD_DIR)
+OUTPUT_DIR ?= $(BUILD_DIR)
 
 # C sources
 C_SOURCES = $(wildcard $(TARGET_DIR)/Core/Src/*.c)
@@ -229,15 +229,15 @@ $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 
 $(OUTPUT_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(OUTPUT_DIR)
 	$(HEX) $< $@
-	
+
 $(OUTPUT_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(OUTPUT_DIR)
-	$(BIN) $< $@	
-	
+	$(BIN) $< $@
+
 $(BUILD_DIR):
-	-mkdir $@	
-	
+	-mkdir -p $@
+
 $(OUTPUT_DIR): $(BUILD_DIR)
-	-mkdir $@
+	-mkdir -p $@
 
 #######################################
 # clean up


### PR DESCRIPTION
Use time between encoder ticks to better estimate low speeds. Calculate an upper bound on velocity based on encoder resolution and time since last tick and use that to update the current velocity estimate when no ticks are observed.

This change improves stability of conditional effects, specifically the damper an inertia, when set at high values.

Once this is merged, I would recommend removing the encoder speed filter entirely, it's no longer necessary, and increasing the cutoff frequency for the accel filter. Additionally, implementing either persistent storage for the encoder resolution, or implementing the getCpr function such that it returns the real encoder resolution instead of 65535 will improve the velocity estimate.

Right now, without a working getCpr or persistent storage for the encoder resolution, I have the value hard coded. Basically any value here is still an improvement over the prior method, even '1', but the correct value will further increase the accuracy of the estimate.

This same method could also be applied to the acceleration calc, which should improve inertia stability and smoothness even more.