### PR TITLE
Fix EEPROM Emulation caching issue on Cortex-M4

### DIFF
--- a/Firmware/FFBoard/Src/flash_helpers.cpp
+++ b/Firmware/FFBoard/Src/flash_helpers.cpp
@@ -21,9 +21,22 @@ cpp_freertos::MutexStandard flashMutex;
 /**
  * Formats the eeprom emulation section to delete all data
  */
+/**
+ * Invalidate the ART data cache after flash operations.
+ * The STM32F4 ART accelerator caches flash reads on the D-bus.
+ * After erasing or programming flash, stale cached values would be
+ * returned unless the cache is explicitly reset. (See ST AN3969)
+ */
+static void Flash_InvalidateDataCache(){
+	__HAL_FLASH_DATA_CACHE_DISABLE();
+	__HAL_FLASH_DATA_CACHE_RESET();
+	__HAL_FLASH_DATA_CACHE_ENABLE();
+}
+
 bool Flash_Format(){
 	HAL_FLASH_Unlock();
 	bool res = (EE_Format() == HAL_OK);
+	Flash_InvalidateDataCache();
 	HAL_FLASH_Lock();
 	return res;
 }
@@ -41,6 +54,7 @@ __weak bool Flash_Init(){
 	__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGSERR);
 
 	bool state = (EE_Init() == EE_OK);
+	Flash_InvalidateDataCache();
 	HAL_FLASH_Lock();
 	return state;
 }
@@ -61,9 +75,11 @@ bool Flash_Write(uint16_t adr,uint16_t dat){
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGAERR);
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGPERR);
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGSERR);
+		Flash_InvalidateDataCache(); // Invalidate before writing because EE_ReadVariable just cached the flash page
 		if(EE_WriteVariable(adr, dat) == HAL_OK){
 			res = true;
 		}
+		Flash_InvalidateDataCache();
 		HAL_FLASH_Lock();
 
 	}
@@ -97,7 +113,9 @@ bool Flash_ReadWriteDefault(uint16_t adr,uint16_t *buf,uint16_t def){
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGAERR);
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGPERR);
 		__HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_PGSERR);
+		Flash_InvalidateDataCache(); // Invalidate before writing because EE_ReadVariable just cached the flash page
 		EE_WriteVariable(adr, def);
+		Flash_InvalidateDataCache();
 		HAL_FLASH_Lock();
 		return false;
 	}


### PR DESCRIPTION
**Description of the Issue:**
Users compiling with newer toolchains (e.g. GCC 13/15) or running on certain STM32F407 hardware were experiencing an issue where saving configurations failed silently. The Configurator/UI reported "Save in flash: OK", but after a reboot, the settings reverted to their defaults.

**Root Cause:**
The STMicroelectronics EEPROM Emulation library (`eeprom.c`) uses consecutive flash reads during `EE_VerifyPageFullWriteVariable` to find an empty slot (0xFFFFFFFF) in the active flash page.
However, on processors with an ART Data Cache (like Cortex-M4/M7), these reads can get cached. If the flash sector was recently erased (or formatted), the memory reads inside the `EE_ReadVariable` loop result in the CPU aggressively caching empty or stale data values. 
When `EE_VerifyPageFullWriteVariable` attempts to write later, the cached (stale) data is read back instead of the actual physical flash data. Because it doesn't see `0xFFFFFFFF`, the library incorrectly assumes the page is completely full (`PAGE_FULL` error). The write is silently skipped and dropped.

**The Solution:**
To resolve this desynchronization between the physical flash and the CPU Data Cache during In-Application Programming (IAP), we explicitly flush/invalidate the data cache right before calling `EE_WriteVariable()`.
- `Flash_InvalidateDataCache()` now correctly wraps the write operation (before and after).
- This ensures the CPU fetches the actual flash transistor state when scanning for empty slots.
- This aligns with STMicroelectronics recommendations in AN3969 for EEPROM Emulation on STM32F4.
**Safety and Regressions:**
- For processors without a Data Cache (e.g. Cortex-M0/M0+), the `__HAL_FLASH_DATA_CACHE_DISABLE` macro is naturally undefined by the ST HAL, so the cache clearing function compiles to an empty, harmless operation.
- The performance impact on high-end MCUs is negligible, as EEPROM writes are extremely rare (only triggered on manual save) and flash programming delays natively dwarf any cache-miss penalty.
- The original code already invoked `Flash_InvalidateDataCache()` immediately *after* the write operation; adding it *before* simply guarantees a clean slate for the pre-write reads.